### PR TITLE
Don't join to task table when querying for last task run

### DIFF
--- a/src/graphql/Task/last-task-run.gql
+++ b/src/graphql/Task/last-task-run.gql
@@ -1,6 +1,6 @@
 query LastTaskRun($id: uuid!) {
   task_run(
-    where: { task: { id: { _eq: $id } }, state: { _neq: "Scheduled" } }
+    where: { task_id: { _eq: $id }, state: { _neq: "Scheduled" } }
     order_by: { state_start_time: desc }
     limit: 1
   ) {


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Improves the task page query by not doing a join in the where clause

cc @cicdw 