### PR TITLE
Don't join to flow table when querying for last flow run

### DIFF
--- a/src/graphql/Flow/last-flow-run.gql
+++ b/src/graphql/Flow/last-flow-run.gql
@@ -1,6 +1,6 @@
 query LastFlowRun($id: uuid!) {
   flow_run(
-    where: { flow: { id: { _eq: $id } }, state: { _neq: "Scheduled" } }
+    where: { flow_id: { _eq: $id }, state: { _neq: "Scheduled" } }
     order_by: { scheduled_start_time: desc }
     limit: 1
   ) {


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Improves the flow page query by not doing a join in the where clause of the last flow run query

cc @cicdw