### PR TITLE
Skip and then restart polling for global queries

### DIFF
--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -67,7 +67,7 @@ export default {
       'releaseTimestamp'
     ]),
     ...mapGetters('sideNav', ['isOpen']),
-    ...mapGetters('tenant', ['tenant', 'tenants']),
+    ...mapGetters('tenant', ['tenant', 'tenants', 'tenantIsSet']),
     ...mapGetters('user', ['memberships', 'user']),
     ...mapGetters('auth0', ['authorizationToken']),
     ...mapGetters('license', ['hasLicense']),
@@ -296,7 +296,11 @@ export default {
       },
       skip() {
         return (
-          !this.isCloud || !this.memberships || !this.user || !this.user.email
+          !this.isCloud ||
+          !this.memberships ||
+          !this.user ||
+          !this.user.email ||
+          !this.tenantIsSet
         )
       },
       fetchPolicy: 'network-only',

--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -139,7 +139,6 @@ export default {
         }
 
         if (this.loadedTiles <= this.numberOfTiles) {
-          // eslint-disable-next-line
           requestAnimationFrame(loadTiles)
         }
       }

--- a/src/store/tenant/index.js
+++ b/src/store/tenant/index.js
@@ -29,7 +29,7 @@ const getters = {
     return state.tenant
   },
   tenantIsSet(state) {
-    return state.tenantIsSet
+    return !!state.tenant?.id
   },
   tenants(state) {
     return state.tenants
@@ -45,7 +45,6 @@ const mutations = {
       throw new Error('passed invalid or empty tenant object')
     }
     state.tenant = { ...tenant }
-    state.tenantIsSet = true
   },
   setTenants(state, tenants) {
     if (tenants?.length === 0) {
@@ -65,7 +64,6 @@ const mutations = {
       prefectAdminSettings: {},
       stripeCustomerID: ''
     }
-    state.tenantIsSet = false
   },
   unsetTenants(state) {
     state.tenants = []

--- a/src/vue-apollo.js
+++ b/src/vue-apollo.js
@@ -96,7 +96,7 @@ const errorAfterware = onError(
             `%c${error.extensions?.code || 'ERROR'}`,
             'color: #B11A04; font-weight:bold;'
           )
-          console.group(`Message: ${error.message}`)
+          console.log(`Message: ${error.message}`)
           console.log('Full log: ', error)
           console.groupEnd()
         })


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This reduces the number of errors in the console when and fixes a bug where polling wasn't correctly restarted for pending invitations when switching backends. This'll look like a bigger PR than necessary only because polling restarts were inconsistent due to the recycled apollo client; the most consistent way to restart polling between switches is to remount the component, so added some frills to make that happen nicely. 

Also fixes an error where the previous `console.group` was swallowing other console messages, so reverted it (@zhen0, messages are working fine for me so lmk if you're still seeing odd behavior)

