### PR TITLE
remove tenant from create project mutation

### DIFF
--- a/src/graphql/Mutations/create-project.gql
+++ b/src/graphql/Mutations/create-project.gql
@@ -1,10 +1,9 @@
 mutation CreateProject(
   $name: String!
   $description: String
-  $tenantId: String!
 ) {
   create_project(
-    input: { name: $name, description: $description, tenant_id: $tenantId }
+    input: { name: $name, description: $description}
   ) {
     id
   }


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Looks like the create project mutation no longer allows a tenant id?  