### PR TITLE
Remove hasura aggregates from flow failure tile

### DIFF
--- a/src/assets/fonts/prefect-icons/style.scss
+++ b/src/assets/fonts/prefect-icons/style.scss
@@ -9,13 +9,13 @@
   // stylelint-disable
   src: url('#{$prefect-font-path}/#{$prefect-font-family}.eot?higzvn');
   src: url('#{$prefect-font-path}/#{$prefect-font-family}.eot?higzvn#iefix')
-      format('embedded-opentype'),
+    format('embedded-opentype'),
     url('#{$prefect-font-path}/#{$prefect-font-family}.ttf?higzvn')
-      format('truetype'),
+    format('truetype'),
     url('#{$prefect-font-path}/#{$prefect-font-family}.woff?higzvn')
-      format('woff'),
+    format('woff'),
     url('#{$prefect-font-path}/#{$prefect-font-family}.svg?higzvn##{$prefect-font-family}')
-      format('svg');
+    format('svg');
   // stylelint-enable
 }
 

--- a/src/components/PaymentCard.vue
+++ b/src/components/PaymentCard.vue
@@ -245,13 +245,13 @@ export default {
 <style scoped>
 /*stylelint-disable */
 .StripeElement {
+  background-color: white;
+  border: 1px solid;
+  border-color: #0009;
+  border-radius: 4px;
   height: 56px;
 
-  padding: 15px 15px;
-  border-color: #0009;
-  border: 1px solid;
-  border-radius: 4px;
-  background-color: white;
+  padding: 15px;
   -webkit-transition: box-shadow 150ms ease;
   transition: box-shadow 150ms ease;
 }

--- a/src/graphql/Dashboard/flow-failures.gql
+++ b/src/graphql/Dashboard/flow-failures.gql
@@ -3,25 +3,9 @@ query FlowFailures ($projectId: uuid, $heartbeat: timestamptz) {
     id
     name
     archived
-    # removing for now since we filter and sort on the failures tile anyway
-    # last_failed_heartbeat: flow_runs_aggregate(where: {state: {_eq: "Failed"}, heartbeat: {_gte: $heartbeat}}) {
-    #     aggregate {
-    #       max {
-    #         heartbeat
-    #       }
-    #     }
-    # }
-    failed_count: flow_runs_aggregate(
-      where: { state: { _eq: "Failed" }, updated: { _gte: $heartbeat } }
-    ) {
-      aggregate {
-        count
-      }
-    }
-    runs_count: flow_runs_aggregate(where: { updated: { _gte: $heartbeat } }) {
-      aggregate {
-        count
-      }
+    flow_runs(where: { state: { _eq: "Failed" }, updated: { _gte: $heartbeat }}){
+        id
+        updated
     }
   }
 }

--- a/src/pages/Dashboard/Failures-Tile.vue
+++ b/src/pages/Dashboard/Failures-Tile.vue
@@ -70,31 +70,19 @@ export default {
   },
   methods: {
     ...mapMutations('sideDrawer', ['openDrawer']),
-    failedRuns(failure) {
-      if (failure?.failed_count?.aggregate) {
-        return failure.failed_count.aggregate.count
-      }
-      return ''
-    },
-    totalRuns(failure) {
-      if (failure?.runs_count?.aggregate) {
-        return failure.runs_count.aggregate.count
-      }
-      return ''
-    },
     sortFailures(failures) {
       return failures.sort((flowRunA, flowRunB) => {
-        if (flowRunA?.failed_count && flowRunB?.failed_count) {
-          const aFailurePercentage =
-            flowRunA.failed_count.aggregate.count /
-            flowRunA.runs_count.aggregate.count
-          const bFailurePercentage =
-            flowRunB.failed_count.aggregate.count /
-            flowRunB.runs_count.aggregate.count
+        if (flowRunA?.flow_runs && flowRunB?.flow_runs) {
+          const lastUpdatedA = flowRunA.flow_runs.sort(
+            (x, y) => x.updated > y.updated
+          )[0]
+          const lastUpdatedB = flowRunB.flow_runs.sort(
+            (x, y) => x.updated > y.updated
+          )[0]
 
-          if (aFailurePercentage > bFailurePercentage) {
+          if (lastUpdatedA > lastUpdatedB) {
             return -1
-          } else if (aFailurePercentage < bFailurePercentage) {
+          } else if (lastUpdatedA < lastUpdatedB) {
             return 1
           }
           return 0
@@ -119,7 +107,7 @@ export default {
       pollInterval: 30000,
       update: data => {
         return data && data.flow
-          ? data.flow.filter(flow => flow.failed_count.aggregate.count > 0)
+          ? data.flow.filter(flow => flow.flow_runs.length > 0)
           : null
       }
     }
@@ -225,13 +213,6 @@ export default {
                   >{{ failure.name }}</router-link
                 >
               </v-list-item-title>
-
-              <v-list-item-subtitle>
-                {{ failedRuns(failure) }}
-                /
-                {{ totalRuns(failure) }}
-                Runs failed
-              </v-list-item-subtitle>
             </v-list-item-content>
             <v-list-item-avatar
               ><v-icon>arrow_right</v-icon></v-list-item-avatar

--- a/src/pages/TeamSettings/Account/Users.vue
+++ b/src/pages/TeamSettings/Account/Users.vue
@@ -287,9 +287,9 @@ export default {
 
 /* stylelint-disable */
 .v-slider__tick-label {
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
+  bottom: 0;
+  left: 0;
+  right: 0;
   top: 8px;
 }
 </style>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -99,10 +99,11 @@
 
   .v-application--is-ltr & {
     .v-input--selection-controls__input {
-      margin-right: 0;
       margin-left: 8px;
+      margin-right: 0;
     }
   }
+
   .v-application--is-rtl & {
     .v-input--selection-controls__input {
       margin-left: 0;


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR updates the Flow failure tile by removing the aggregate queries; I don't think the incremental value of these was very high.  Now, you click a Failed Flow and you are taken to a very informative Flow dashboard which includes run history and an ERRORS tile.

Here's what the new tile looks like: 
![image](https://user-images.githubusercontent.com/13255838/89135042-2f06ed00-d4df-11ea-9850-bba31c8276df.png)

**NOTE**: If accepted, I plan to do the same thing to the Task failure tile