### PR TITLE
Remove LogRocket from Server deployments

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,6 @@ if (
   process.env.VUE_APP_LOG_ROCKET_PUBLIC_ID &&
   process.env.VUE_APP_BASE_URL?.includes('cloud.prefect.io')
 ) {
-  console.log('this shouldnt run')
   LogRocket.init(process.env.VUE_APP_LOG_ROCKET_PUBLIC_ID, {
     release: process.env.VUE_APP_BASE_URL,
     network: {


### PR DESCRIPTION

PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Only initialize LogRocket if the base url is a Cloud deployment. 

Bugfix: fixes issue were `createAPIToken` wasn't being blocked from LogRocket

Resolves: #37