### PR TITLE
Speed up task failures tile

### DIFF
--- a/src/graphql/Dashboard/failed-task.gql
+++ b/src/graphql/Dashboard/failed-task.gql
@@ -1,8 +1,0 @@
-query FailedTaskDetails($taskId: uuid!, $heartbeat: timestamptz) {
-          task_by_pk(id: $taskId) {
-            task_runs(where: { updated: { _gte: $heartbeat } }) {
-              id
-              state
-            }
-          }
-        }

--- a/src/graphql/Dashboard/failures.gql
+++ b/src/graphql/Dashboard/failures.gql
@@ -1,23 +1,15 @@
 query FailedTasks($heartbeat: timestamptz) {
-  task_run
-    (where: {
-        _and: [{
-            state: {
-              _eq: "Failed"
-            }
-          },
-          {
-            updated: {
-              _gte: $heartbeat
-            }
-          }
-        ]
-      }
-      distinct_on: task_id) {
+  task_run(
+    where: { state: { _eq: "Failed" }, updated: { _gte: $heartbeat } }
+    distinct_on: task_id
+  ) {
+    id
+    task {
       id
-      task {
-        id
+      name
+      flow {
         name
       }
     }
+  }
 }

--- a/src/graphql/Dashboard/flow-by-task.gql
+++ b/src/graphql/Dashboard/flow-by-task.gql
@@ -1,5 +1,0 @@
-query FlowByTaskId($taskId: uuid) {
-  flow (where: {tasks: {id: {_eq: $taskId}}}){
-    name
-  }
-}

--- a/src/pages/Dashboard/Errors-Tile.vue
+++ b/src/pages/Dashboard/Errors-Tile.vue
@@ -98,9 +98,6 @@ export default {
         }
         return 0
       })
-    },
-    calcHeartBeat() {
-      return oneAgo(this.selectedDateFilter)
     }
   },
   apollo: {
@@ -211,7 +208,7 @@ export default {
           min-height="40px"
           transition="fade"
         >
-          <TaskItem :failure="failure" :heartbeat="calcHeartBeat()" />
+          <TaskItem :failure="failure" />
         </v-lazy>
       </v-slide-y-reverse-transition>
       <v-slide-y-transition v-else leave-absolute group>

--- a/src/pages/Dashboard/Task-Item.vue
+++ b/src/pages/Dashboard/Task-Item.vue
@@ -5,10 +5,6 @@ export default {
     failure: {
       type: Object,
       required: true
-    },
-    heartbeat: {
-      type: String,
-      required: true
     }
   },
   data() {
@@ -17,70 +13,12 @@ export default {
       queryError: false
     }
   },
-  computed: {
-    flowName() {
-      return this.flow[0]?.name
-    }
-  },
-  watch: {},
-  methods: {
-    failedRuns(task) {
-      const failedRuns = task?.task_runs?.filter(run => {
-        return run.state === 'Failed'
-      })
-      return failedRuns?.length
-    },
-    totalRuns(task) {
-      return task?.task_runs?.length
-    }
-  },
-  apollo: {
-    task: {
-      query: require('@/graphql/Dashboard/failed-task.gql'),
-      variables() {
-        return { taskId: this.failure.task.id, heartbeat: this.heartbeat }
-      },
-      // skip: true,
-      loadingKey: 'loading',
-      pollInterval: 0,
-      error() {
-        this.queryError = true
-      },
-      update: data => {
-        return data.task_by_pk
-      }
-    },
-    flow: {
-      query: require('@/graphql/Dashboard/flow-by-task.gql'),
-      variables() {
-        return { taskId: this.failure.task.id, heartbeat: this.heartbeat }
-      },
-      // skip: true,
-      loadingKey: 'loading',
-      pollInterval: 0,
-      error() {
-        this.queryError = true
-      },
-      update: data => {
-        return data.flow
-      }
-    }
-  }
+  watch: {}
 }
 </script>
 
 <template>
-  <div v-if="!task && loading" class="loading apollo"
-    ><v-skeleton-loader key="skeleton" type="list-item-two-line">
-    </v-skeleton-loader
-  ></div>
-  <!-- Error -->
-  <div v-else-if="queryError"
-    ><v-skeleton-loader key="skeleton" type="list-item-two-line">
-    </v-skeleton-loader>
-  </div>
-  <!-- Result -->
-  <div v-else-if="task" class="result apollo">
+  <div class="result apollo">
     <v-list-item
       class="text-truncate"
       :to="{
@@ -97,7 +35,7 @@ export default {
               params: { id: failure.task.id }
             }"
           >
-            {{ flowName }}
+            {{ failure.task.flow.name }}
             <span class="font-weight-bold">
               <v-icon style="font-size: 12px;">
                 chevron_right
@@ -106,20 +44,8 @@ export default {
             {{ failure.task.name }}
           </router-link>
         </v-list-item-title>
-
-        <v-list-item-subtitle>
-          {{ failedRuns(task) }}
-          /
-          {{ totalRuns(task) }}
-          Runs failed
-        </v-list-item-subtitle>
       </v-list-item-content>
       <v-list-item-avatar><v-icon>arrow_right</v-icon></v-list-item-avatar>
     </v-list-item>
   </div>
-  <!-- No result -->
-  <div v-else class="no-result apollo"
-    ><v-skeleton-loader key="skeleton" type="list-item-two-line">
-    </v-skeleton-loader
-  ></div>
 </template>


### PR DESCRIPTION
This PR adjusts the task failures tile to be more performant.

Previously, the tile did the following:
- load all tasks that have failed task runs
- for each task, query for its flow
- for each task, query for all task runs and count the task runs (in the client)

Following the pattern in the failed flows tile, this PR removes the count, which dramatically simplifies the pattern and lets us avoid two complex db calls entirely.