### PR TITLE
Speed up last task run query

### DIFF
--- a/src/graphql/Task/last-task-run.gql
+++ b/src/graphql/Task/last-task-run.gql
@@ -1,7 +1,11 @@
 query LastTaskRun($id: uuid!) {
   task_run(
-    where: { task_id: { _eq: $id }, state: { _neq: "Scheduled" } }
-    order_by: { state_start_time: desc }
+    where: {
+      task_id: { _eq: $id }
+      state: { _neq: "Scheduled" }
+      start_time: { _is_null: false }
+    }
+    order_by: { updated: desc }
     limit: 1
   ) {
     id


### PR DESCRIPTION
The last task run query ordered the task run table by `state_start_time`, which is unindexed. This query achieves practically the same effect by sorting by `updated` (which is indexed) and only including runs that have a non-null start time. I believe this makes the task page load meaningfully quicker.