### PR TITLE
Fix admin settings references and Cloud Hooks form

### DIFF
--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -151,7 +151,7 @@ export default {
       if (
         this.canEdit &&
         this.editable &&
-        this.tenant.prefectAdminSettings.notifications
+        this.tenant.prefectAdminSettings?.notifications
       ) {
         return featureFlaggedCloudHookTypes
       } else {
@@ -227,7 +227,8 @@ export default {
           name: this.tempName,
           states: this.tempStates,
           config: this.tempConfig,
-          type: this.tempType
+          type: this.tempType,
+          tenant_id: this.tenant.id
         }
 
         const createCloudHookResult = await this.$apollo.mutate({

--- a/src/mixins/cloudHookMixin.js
+++ b/src/mixins/cloudHookMixin.js
@@ -22,7 +22,7 @@ export const cloudHookMixin = {
   computed: {
     ...mapGetters('tenant', ['tenant']),
     cloudHookTypes() {
-      if (this.tenant.prefectAdminSettings.notifications)
+      if (this.tenant.prefectAdminSettings?.notifications)
         return featureFlaggedCloudHookTypes
       return openCloudHookTypes
     }

--- a/src/pages/Flow/Settings/General.vue
+++ b/src/pages/Flow/Settings/General.vue
@@ -38,6 +38,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters('api', ['isCloud']),
     ...mapGetters('tenant', ['tenant', 'role']),
     ...mapGetters('license', ['permissions']),
     sortedProjects() {
@@ -62,7 +63,7 @@ export default {
       return this.selected.projectId !== this.flow.project.id
     },
     versionLockingPermitted() {
-      return this.permissions.includes('feature:version-locking')
+      return this.permissions?.includes('feature:version-locking')
     }
   },
   methods: {
@@ -365,7 +366,7 @@ export default {
           </div>
         </v-col>
       </v-row>
-      <v-row class="mt-8">
+      <v-row v-if="isCloud" class="mt-8">
         <v-col cols="12" class="pb-0">
           <div class="title primary--text">
             <!-- We don't really have the visual language necessary to use these I think -->


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Updates Cloud-only references to admin settings (fixes Cloud Hook forms for Server)
Updates Cloud Hook creation input to include the current tenant id