### PR TITLE
Fix issue with task failures tile having wrong color

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,3 +5,4 @@
 - Switch the errors tile to become a failed tasks tile and add better timeout error handling [#6](https://github.com/PrefectHQ/prefect-ui/pull/6)
 - Improve the error message design on the flow failures and task failures tiles[#13](https://github.com/PrefectHQ/prefect-ui/pull/13)
 - Fix order of "last ten runs" on the flows page [#50](https://github.com/PrefectHQ/ui/pull/50)
+- Fix issue with Failed Tasks tile incorrectly displaying with a red color - [#88](https://github.com/PrefectHQ/ui/issues/88)

--- a/src/pages/Flow/Errors-Tile.vue
+++ b/src/pages/Flow/Errors-Tile.vue
@@ -193,7 +193,7 @@ export default {
       </v-slide-y-reverse-transition>
 
       <v-slide-y-reverse-transition
-        v-else-if="errors && errors.length > 0"
+        v-else-if="filteredErrors && filteredErrors.length > 0"
         leave-absolute
         mode="out-in"
         group

--- a/src/pages/Flow/Errors-Tile.vue
+++ b/src/pages/Flow/Errors-Tile.vue
@@ -128,7 +128,7 @@ export default {
           ? 'grey'
           : loading > 0
           ? 'secondaryGray'
-          : errors && errors.length > 0
+          : filteredErrors && filteredErrors.length > 0
           ? 'Failed'
           : 'Success'
       "
@@ -148,7 +148,7 @@ export default {
           :icon-color="
             flow.archived || loading > 0
               ? 'grey'
-              : errors && errors.length > 0
+              : filteredErrors && filteredErrors.length > 0
               ? 'Failed'
               : 'Success'
           "


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR fixes an issue where the Task Failures tile was incorrectly using `errors` instead of `filteredErrors` to determine its displayed color - `errors` will consist entirely of flow runs (regardless of failures), whereas `filteredErrors` is an actual list of errors at the task run level, across all flow runs.

Closes #88 