### PR TITLE
Add Created On column to Flow Table

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,3 +8,4 @@
 - Fix issue with Failed Tasks tile incorrectly displaying with a red color - [#88](https://github.com/PrefectHQ/ui/issues/88)
 - Add cancellation button to Flow Run pages [#92](https://github.com/PrefectHQ/ui/pull/92)
 - Name the restart mutation and fix casing on the restart mutation variable [#98](https://github.com/PrefectHQ/ui/pull/98)
+- Add Created On column to Flow Table - [#103](https://github.com/PrefectHQ/ui/pull/103)

--- a/src/pages/Dashboard/FlowTable-Tile.vue
+++ b/src/pages/Dashboard/FlowTable-Tile.vue
@@ -30,6 +30,11 @@ const serverHeaders = [
     value: 'version',
     sortable: false,
     width: '7.5%'
+  },
+  {
+    text: 'Created On',
+    value: 'created',
+    width: '15%'
   }
 ]
 
@@ -372,6 +377,12 @@ export default {
         <template v-slot:item.flow_runs="{ item }">
           <div class="position-relative allow-overflow">
             <LastTenRuns :flow-id="item.id" :archived="item.archived" />
+          </div>
+        </template>
+
+        <template v-slot:item.created="{ item }">
+          <div class="truncate">
+            {{ formatTime(item.created) }}
           </div>
         </template>
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR adds a new column to the flow table: "Created On".  I found myself registering / reregistering flows a lot for testing, and having to sift through names was not ideal -- this allows me to filter by newest flows.