### PR TITLE
Update the schedule toggle component to use an optimistic response

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,3 +7,4 @@
 - Fix order of "last ten runs" on the flows page [#50](https://github.com/PrefectHQ/ui/pull/50)
 - Fix issue with Failed Tasks tile incorrectly displaying with a red color - [#88](https://github.com/PrefectHQ/ui/issues/88)
 - Add cancellation button to Flow Run pages [#92](https://github.com/PrefectHQ/ui/pull/92)
+- Improve schedule toggling reactivity [#104](https://github.com/PrefectHQ/ui/pull/104/files)

--- a/src/components/ScheduleToggle.vue
+++ b/src/components/ScheduleToggle.vue
@@ -14,7 +14,8 @@ export default {
   },
   data() {
     return {
-      loading: false
+      loading: false,
+      optimisticIsScheduled: this.flow.is_schedule_active
     }
   },
   computed: {
@@ -25,14 +26,9 @@ export default {
     isReadOnlyUser() {
       return this.role === 'READ_ONLY_USER'
     },
-    isScheduled: {
-      get() {
-        if (this.archived) return false
-        return this.flow.is_schedule_active
-      },
-      set() {
-        return
-      }
+    isScheduled() {
+      if (this.archived) return false
+      return this.optimisticIsScheduled
     },
     schedule() {
       return (
@@ -57,6 +53,7 @@ export default {
             this.alertShow = true
             this.alertMessage = 'Schedule paused'
             this.alertType = 'info'
+            this.optimisticIsScheduled = false
           } else {
             this.alertShow = true
             this.alertMessage =
@@ -74,6 +71,7 @@ export default {
             this.alertShow = true
             this.alertMessage = 'Schedule activated'
             this.alertType = 'info'
+            this.optimisticIsScheduled = true
           } else {
             this.alertShow = true
             this.alertMessage =


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Updates the schedule toggle component (used primarily on the flow page) to use a locally-set prop (defaulting to the passed flow schedule) to determine its active status. This should improve reactivity when schedules are toggled.

cc @cicdw 