### PR TITLE
Maintenance mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Update connection icon if Cloud is in maintenance mode - [#155](https://github.com/PrefectHQ/ui/pull/155)
 
 ### Bugfixes
 

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -263,9 +263,9 @@ export default {
             color="accentPink"
             tile
           >
-            Prefect Cloud is temporarily in maintenance mode for routine
-            servicing - during this time, no new runs will be released to your
-            Agents and state updates may be delayed.
+            Prefect Cloud is undergoing routine maintenance; during this time,
+            no new runs will be released to your Agents and state updates may be
+            delayed.
           </v-alert>
         </v-card-text>
         <v-card-actions class="pt-0">

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -246,12 +246,19 @@ export default {
             <span v-else-if="connecting">Connecting</span>
             <span v-else>Couldn't connect</span>
             to <span class="font-weight-bold">{{ url }}</span> <br /><br />
-            <span v-if="apiMode != 'normal'"
-              >Prefect Cloud is temporarily in maintenance mode for routine
-              servicing - during this time, no new runs will be released to your
-              Agents and state updates may be delayed.</span
-            >
           </p>
+          <v-alert
+            v-if="apiMode != 'normal'"
+            border="left"
+            colored-border
+            class="text-body-2"
+            type="warning"
+            tile
+          >
+            Prefect Cloud is temporarily in maintenance mode for routine
+            servicing - during this time, no new runs will be released to your
+            Agents and state updates may be delayed.
+          </v-alert>
         </v-card-text>
         <v-card-actions class="pt-0">
           <v-spacer></v-spacer>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -245,7 +245,12 @@ export default {
             <span v-if="connected">Connected</span>
             <span v-else-if="connecting">Connecting</span>
             <span v-else>Couldn't connect</span>
-            to <span class="font-weight-bold">{{ url }}</span>
+            to <span class="font-weight-bold">{{ url }}</span> <br /><br />
+            <span v-if="apiMode != 'normal'"
+              >Prefect Cloud is temporarily in maintenance mode for routine
+              servicing - during this time, no new runs will be released to your
+              Agents and state updates may be delayed.</span
+            >
           </p>
         </v-card-text>
         <v-card-actions class="pt-0">

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -20,6 +20,7 @@ export default {
       'isServer',
       'isCloud',
       'url',
+      'apiMode',
       'connected',
       'connecting',
       'retries'
@@ -27,7 +28,12 @@ export default {
     ...mapGetters('license', ['hasLicense']),
     ...mapGetters('tenant', ['tenant', 'tenantIsSet']),
     ...mapGetters('user', ['memberships', 'user', 'auth0User', 'timezone']),
+    iconColor() {
+      return this.apiMode != 'normal' ? 'secondary' : 'white'
+    },
     connectedIcon() {
+      if (this.connected && this.apiMode != 'normal')
+        return 'signal_cellular_connected_no_internet_4_bar'
       if (this.connected) return 'signal_cellular_4_bar'
       if (this.connecting) return 'signal_cellular_null'
       return 'signal_cellular_off'
@@ -211,7 +217,7 @@ export default {
           text
           icon
           large
-          color="white"
+          :color="iconColor"
           v-on="on"
           @focus="connectionMenu = true"
           @blur="connectionMenu = false"

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -28,12 +28,7 @@ export default {
     ...mapGetters('license', ['hasLicense']),
     ...mapGetters('tenant', ['tenant', 'tenantIsSet']),
     ...mapGetters('user', ['memberships', 'user', 'auth0User', 'timezone']),
-    iconColor() {
-      return this.apiMode != 'normal' ? 'secondary' : 'white'
-    },
     connectedIcon() {
-      if (this.connected && this.apiMode != 'normal')
-        return 'signal_cellular_connected_no_internet_4_bar'
       if (this.connected) return 'signal_cellular_4_bar'
       if (this.connecting) return 'signal_cellular_null'
       return 'signal_cellular_off'
@@ -217,7 +212,7 @@ export default {
           text
           icon
           large
-          :color="iconColor"
+          color="white"
           v-on="on"
           @focus="connectionMenu = true"
           @blur="connectionMenu = false"
@@ -237,6 +232,18 @@ export default {
           >
             fas fa-spinner fa-pulse
           </v-icon>
+          <v-icon
+            v-if="apiMode !== 'normal'"
+            small
+            color="accentPink"
+            class="position-absolute"
+            :style="{
+              bottom: '-8px',
+              right: '0'
+            }"
+          >
+            fas fa-exclamation
+          </v-icon>
         </v-btn>
       </template>
       <v-card tile class="pa-0" max-width="320">
@@ -248,11 +255,12 @@ export default {
             to <span class="font-weight-bold">{{ url }}</span> <br /><br />
           </p>
           <v-alert
-            v-if="apiMode != 'normal'"
+            v-if="apiMode !== 'normal'"
             border="left"
             colored-border
             class="text-body-2"
             type="warning"
+            color="accentPink"
             tile
           >
             Prefect Cloud is temporarily in maintenance mode for routine

--- a/src/graphql/api.gql
+++ b/src/graphql/api.gql
@@ -1,6 +1,7 @@
 query Api {
   api {
     backend
+    mode
     version
     release_timestamp
   }

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -10,6 +10,7 @@ const state = {
   connectionMessage: null,
   connectionTimeout: null,
   releaseTimestamp: null,
+  apiMode: 'normal',
   cloudUrl: process.env.VUE_APP_CLOUD_URL,
   retries: 0,
   serverUrl:
@@ -20,6 +21,9 @@ const state = {
 const getters = {
   backend(state) {
     return state.backend
+  },
+  apiMode(state) {
+    return state.apiMode || 'normal'
   },
   connected(state) {
     return state.connected
@@ -94,6 +98,9 @@ const mutations = {
   setReleaseTimestamp(state, timestamp) {
     state.releaseTimestamp = timestamp
   },
+  setApiMode(state, apiMode) {
+    state.apiMode = apiMode
+  },
   unsetReleaseTimetamp(state) {
     state.releaseTimestamp = null
   },
@@ -127,6 +134,7 @@ const actions = {
       commit('setReleaseTimestamp', data.api.release_timestamp)
       commit('setVersion', data.api.version)
       commit('setConnected', true)
+      commit('setApiMode', data.api.mode)
     } catch (error) {
       commit('unsetReleaseTimetamp')
       commit('unsetVersion')
@@ -163,6 +171,7 @@ const actions = {
           commit('setConnectionMessage', 'Connected')
           commit('setRetries', 0)
           commit('setConnected', true)
+          commit('setApiMode', data.api.mode)
         }
       } catch (e) {
         commit('setConnectionMessage', e)

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -10,7 +10,7 @@ const state = {
   connectionMessage: null,
   connectionTimeout: null,
   releaseTimestamp: null,
-  apiMode: 'normal',
+  apiMode: null,
   cloudUrl: process.env.VUE_APP_CLOUD_URL,
   retries: 0,
   serverUrl:

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -171,7 +171,7 @@ const actions = {
           commit('setConnectionMessage', 'Connected')
           commit('setRetries', 0)
           commit('setConnected', true)
-          commit('setApiMode', data.api.mode)
+          commit('setApiMode', 'maintenance')
         }
       } catch (e) {
         commit('setConnectionMessage', e)

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -171,7 +171,7 @@ const actions = {
           commit('setConnectionMessage', 'Connected')
           commit('setRetries', 0)
           commit('setConnected', true)
-          commit('setApiMode', 'maintenance')
+          commit('setApiMode', data.api.mode)
         }
       } catch (e) {
         commit('setConnectionMessage', e)

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -23,7 +23,7 @@ const getters = {
     return state.backend
   },
   apiMode(state) {
-    return state.apiMode || 'normal'
+    return state.apiMode
   },
   connected(state) {
     return state.connected


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR updates the upper right connection icon to respond to Cloud's maintenance mode.  When in maintenance mode, the following will be displayed (API address blacked out since this was in an internal environment):
![example](https://user-images.githubusercontent.com/13255838/91348158-3f398180-e798-11ea-9a98-37ff07223627.png)


Note that this change is only compatible with versions of Server that include this PR: https://github.com/PrefectHQ/server/pull/59 (already merged)