### PR TITLE
Cut changelog ahead of 2020-08-27 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,16 @@
 
 ### Features and Improvements
 
+- None
+
+### Bugfixes
+
+- None
+
+## 2020-08-27
+
+### Features and Improvements
+
 - Remove stale references to `run_count` from all GQL queries - [#157](https://github.com/PrefectHQ/ui/pull/157)
 
 ### Bugfixes


### PR DESCRIPTION
## 2020-08-27

### Features and Improvements

- Remove stale references to `run_count` from all GQL queries - [#157](https://github.com/PrefectHQ/ui/pull/157)

### Bugfixes

- Don't show maintenance mode on load (unless it's true) [#159](https://github.com/PrefectHQ/ui/pull/159)
