### PR TITLE
BUGFIX: Flow page details tile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 
 - Fix log generation when restarting flow runs from failure - [#163](https://github.com/PrefectHQ/ui/pull/163)
 - Fix membership invitation toasts [#166](https://github.com/PrefectHQ/ui/pull/166)
+- Fix bad labels references for older flows that were preventing the Flow page details tile from rendering correctly [#171](https://github.com/PrefectHQ/ui/pull/171)
 
 ## 2020-08-27
 

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -309,7 +309,7 @@ export default {
                 >
                   <template v-slot:activator="{ on }">
                     <v-btn
-                      :color="labels.length < 1 ? 'info' : null"
+                      :color="labels && labels.length < 1 ? 'info' : null"
                       text
                       icon
                       x-small
@@ -336,7 +336,7 @@ export default {
                       >.
 
                       <v-alert
-                        v-if="labels.length < 1"
+                        v-if="labels && labels.length < 1"
                         border="left"
                         colored-border
                         type="info"
@@ -442,7 +442,10 @@ export default {
               </v-list-item-subtitle>
 
               <div
-                v-if="(newLabels && newLabels.length > 0) || labels.length > 0"
+                v-if="
+                  (newLabels && newLabels.length > 0) ||
+                    (labels && labels.length > 0)
+                "
               >
                 <Label
                   v-for="(label, i) in newLabels || labels"


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes bad labels references for older flows that were preventing the Flow page details tile from rendering correctly.