### PR TITLE
remove requirement that api token name is more than 2 characters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Remove token name length requirement in run flow tutorial [#174](https://github.com/PrefectHQ/ui/pull/174)
 
 ## 2020-08-28
 

--- a/src/pages/Tutorials/FlowRun/RunLocalAgentStep.vue
+++ b/src/pages/Tutorials/FlowRun/RunLocalAgentStep.vue
@@ -36,7 +36,7 @@ export default {
       }, 2000)
     },
     async generateAgentToken() {
-      if (!this.agentTokenName || this.agentTokenName.length < 3) return
+      if (!this.agentTokenName) return
 
       try {
         const name = this.agentTokenName


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Tiny change to run flow tutorial to remove the token length requirement