### PR TITLE
Scrollbars update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,11 +4,11 @@
 
 ### Features and Improvements
 
-- None
+- Update scrollbars with platform-specific styling [#177](https://github.com/PrefectHQ/ui/pull/177)
 
 ### Bugfixes
 
-- None
+- Fix "overenthusiastic" scrollbars on non-Mac systems [#177](https://github.com/PrefectHQ/ui/pull/177)
 
 ## 2020-08-28
 

--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,8 @@
       by Code owners as they can have serious detrimental impacts 
       which will not be seen until after deployment.
      -->
-    <meta 
-      http-equiv="Content-Security-Policy" 
+    <meta
+      http-equiv="Content-Security-Policy"
       content="
       default-src *;
       script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdn.lr-ingest.io https://kit.fontawesome.com https://js.stripe.com;
@@ -20,20 +20,21 @@
       frame-src https://login.prefect.io https://prefect.auth0.com https://js.stripe.com https://cloud.prefect.io;
       child-src data: blob:;
       worker-src data: blob: 'self';
-    ">
+    "
+    />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-    <meta name="msapplication-TileColor" content="#2d89ef">
-    <meta name="theme-color" content="#ffffff">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+    <meta name="msapplication-TileColor" content="#2d89ef" />
+    <meta name="theme-color" content="#ffffff" />
 
     <title>Prefect</title>
     <link
@@ -43,7 +44,9 @@
 
     <script
       src="https://kit.fontawesome.com/f222ce9ce9.js"
-      crossorigin="anonymous" async></script>
+      crossorigin="anonymous"
+      async
+    ></script>
     <script src="https://js.stripe.com/v3/" async></script>
   </head>
   <body>
@@ -51,7 +54,7 @@
       <strong>
         We're sorry but the Prefect UI doesn't work properly without JavaScript
         enabled. Please enable it to continue.
-        </strong>
+      </strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/src/main.js
+++ b/src/main.js
@@ -155,6 +155,11 @@ new Vue({
   render: h => h(App)
 }).$mount('#app')
 
-if (navigator?.platform !== 'MacIntel') {
-  document.body.classList.add('not-mac')
+try {
+  if (navigator?.platform !== 'MacIntel') {
+    document.body.classList.add('not-mac')
+  }
+} catch {
+  // eslint-disable-next-line no-console
+  console.info('Unable to apply platform-specific scrollbar styles.')
 }

--- a/src/main.js
+++ b/src/main.js
@@ -154,3 +154,7 @@ new Vue({
   apolloProvider: defaultApolloProvider,
   render: h => h(App)
 }).$mount('#app')
+
+if (navigator?.platform !== 'MacIntel') {
+  document.body.classList.add('not-mac')
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -3,7 +3,7 @@ body {
   overflow: overlay;
 }
 
-* {
+.not-mac * {
   box-sizing: border-box;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,3 +1,42 @@
+
+html, body {
+  overflow: overlay;
+}
+
+* {
+  scrollbar-width: thin;
+}
+
+* {
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+
+  ::-webkit-scrollbar {
+    background-color: #fff;
+    width: 16px;
+  }
+
+  /* background of the scrollbar except button or resizer */
+  ::-webkit-scrollbar-track {
+    background-color: #fff;
+  }
+
+  /* scrollbar itself */
+  ::-webkit-scrollbar-thumb {
+    background-color: #babac0;
+    border-radius: 16px;
+    border: 4px solid #fff;
+    min-height: 25px;
+
+  }
+
+  /* set button(top and bottom of the scrollbar) */
+  ::-webkit-scrollbar-button {
+    display:none;
+  }
+}
+
+
 /*
   This is the fade transition css class overrides
 */

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,5 +1,5 @@
-
-html, body {
+html,
+body {
   overflow: overlay;
 }
 
@@ -12,8 +12,8 @@ html, body {
   // ... which is just FireFox for now.
   // the -webkit-* selectors will be deprecated at some point
   // so this will serve as a fallback
-  scrollbar-width: thin;
   scrollbar-color: #babac0 transparent;
+  scrollbar-width: thin;
 
   // Styles the scrollbar container
   ::-webkit-scrollbar {
@@ -29,17 +29,17 @@ html, body {
   // Styles scrollbar body
   ::-webkit-scrollbar-thumb {
     background-color: #babac0;
-    border-radius: 16px;
     border: 4px solid #fff;
+    border-radius: 16px;
     min-height: 25px;
   }
 
   // Removes scrollar arrow buttons
+  /* stylelint-disable-next-line */
   ::-webkit-scrollbar-button {
-    display:none;
+    display: none;
   }
 }
-
 
 /*
   This is the fade transition css class overrides

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -7,29 +7,34 @@ html, body {
   box-sizing: border-box;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
+
+  // This is for scrollbar-css compliant browsers only
+  // ... which is just FireFox for now.
+  // the -webkit-* selectors will be deprecated at some point
+  // so this will serve as a fallback
   scrollbar-width: thin;
   scrollbar-color: #babac0 transparent;
 
+  // Styles the scrollbar container
   ::-webkit-scrollbar {
-    background-color: #fff;
+    background-color: transparent;
     width: 16px;
   }
 
-  /* background of the scrollbar except button or resizer */
+  // Removes track default background
   ::-webkit-scrollbar-track {
-    background-color: #fff;
+    background-color: transparent;
   }
 
-  /* scrollbar itself */
+  // Styles scrollbar body
   ::-webkit-scrollbar-thumb {
     background-color: #babac0;
     border-radius: 16px;
     border: 4px solid #fff;
     min-height: 25px;
-
   }
 
-  /* set button(top and bottom of the scrollbar) */
+  // Removes scrollar arrow buttons
   ::-webkit-scrollbar-button {
     display:none;
   }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -4,12 +4,11 @@ html, body {
 }
 
 * {
-  scrollbar-width: thin;
-}
-
-* {
+  box-sizing: border-box;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
+  scrollbar-width: thin;
+  scrollbar-color: #babac0 transparent;
 
   ::-webkit-scrollbar {
     background-color: #fff;


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
Overrides (non-Mac) platform and browser-specific scrollbars styling for Firefox and Webkit-based browsers - scrollbars should no longer be visible at all times for those browsers and should more closely match original design specs. The exception to this is Firefox, which would require a heavier JavaScript-based solution so went with a "close-enough" CSS fix instead.

Resolves: #175

cc @jnoynaert
