### PR TITLE
Display # of mapped children (when available)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Display number of expected mapped runs when the data exists - [#173](https://github.com/PrefectHQ/ui/issues/173)
 
 ### Bugfixes
 

--- a/src/components/Schematics/Preview-Dynamic.vue
+++ b/src/components/Schematics/Preview-Dynamic.vue
@@ -150,7 +150,9 @@ export default {
               0.13.5+
             </span>
             <span v-else>
-              The number of mapped children expected to run.
+              The number of mapped children expected to run. Note that the
+              number of active mapped runs may be less than this if some have
+              not begun running yet.
             </span>
           </v-tooltip>
         </v-col>

--- a/src/components/Schematics/Preview-Dynamic.vue
+++ b/src/components/Schematics/Preview-Dynamic.vue
@@ -134,12 +134,25 @@ export default {
         </v-col>
       </v-row>
 
-      <v-row>
+      <v-row v-if="task.state == 'Mapped'">
         <v-col cols="6" class="pt-0">
-          <span class="black--text">Class:</span>
+          <span class="black--text">Expected Runs:</span>
         </v-col>
         <v-col cols="6" class="text-right pt-0">
-          {{ task.task.type | typeClass }}
+          <v-tooltip top>
+            <template v-slot:activator="{ on }">
+              <span v-on="on">
+                {{ task.serialized_state.n_map_states || 'unknown' }}
+              </span>
+            </template>
+            <span v-if="!task.serialized_state.n_map_states">
+              This data is only available on Flows registered with Prefect Core
+              0.13.5+
+            </span>
+            <span v-else>
+              The number of mapped children expected to run.
+            </span>
+          </v-tooltip>
         </v-col>
       </v-row>
 

--- a/src/pages/TaskRun/Details-Tile.vue
+++ b/src/pages/TaskRun/Details-Tile.vue
@@ -112,7 +112,9 @@ export default {
                     Core 0.13.5+
                   </span>
                   <span v-else>
-                    The number of mapped children expected to run.
+                    The number of mapped children expected to run. Note that the
+                    number of active mapped runs may be less than this if some
+                    have not begun running yet.
                   </span>
                 </v-tooltip>
               </v-col>

--- a/src/pages/TaskRun/Details-Tile.vue
+++ b/src/pages/TaskRun/Details-Tile.vue
@@ -98,7 +98,7 @@ export default {
           <v-list-item-subtitle class="caption">
             <v-row v-if="taskRun.state == 'Mapped'" no-gutters>
               <v-col cols="6">
-                Expected Mapped Children
+                Expected Mapped Runs
               </v-col>
               <v-col cols="6" class="text-right font-weight-bold">
                 <v-tooltip top>

--- a/src/pages/TaskRun/Details-Tile.vue
+++ b/src/pages/TaskRun/Details-Tile.vue
@@ -96,6 +96,28 @@ export default {
       <v-list-item dense class="pa-0">
         <v-list-item-content>
           <v-list-item-subtitle class="caption">
+            <v-row v-if="taskRun.state == 'Mapped'" no-gutters>
+              <v-col cols="6">
+                Expected Mapped Children
+              </v-col>
+              <v-col cols="6" class="text-right font-weight-bold">
+                <v-tooltip top>
+                  <template v-slot:activator="{ on }">
+                    <span v-on="on">
+                      {{ taskRun.serialized_state.n_map_states || 'unknown' }}
+                    </span>
+                  </template>
+                  <span v-if="!taskRun.serialized_state.n_map_states">
+                    This data is only available on Flows registered with Prefect
+                    Core 0.13.5+
+                  </span>
+                  <span v-else>
+                    The number of mapped children expected to run.
+                  </span>
+                </v-tooltip>
+              </v-col>
+            </v-row>
+
             <v-row v-if="taskRun.start_time" no-gutters>
               <v-col cols="6">
                 Started
@@ -168,19 +190,6 @@ export default {
                     {{ formatTime(taskRun.updated) }}
                   </div>
                 </v-tooltip>
-              </v-col>
-            </v-row>
-
-            <v-row no-gutters>
-              <v-col cols="6">
-                Class
-              </v-col>
-              <v-col
-                v-if="taskRun.task"
-                cols="6"
-                class="text-right font-weight-bold"
-              >
-                {{ taskRun.task.type | typeClass }}
               </v-col>
             </v-row>
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR displays the _expected_ number of mapped tasks to be generated by a mapped pipeline.  Note:
- I use the term "expected" because if something goes wrong, the number could be smaller
- this data is only available on Core versions 0.13.5+ (note this has not been released yet)

I additionally chose to remove `Class` as a displayed field.  It's Python specific and more often than not too generic to be useful.

Closes #173