### PR TITLE
Fix mapped children restart from failure bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@
 
 ### Bugfixes
 
-- None
+- Fix bug with Restart from Failed rerunning successfull mapped child tasks - [#182](https://github.com/PrefectHQ/ui/issues/182)
 
 ## 2020-08-31a
 

--- a/src/graphql/TaskRun/utility_downstream_tasks.gql
+++ b/src/graphql/TaskRun/utility_downstream_tasks.gql
@@ -4,6 +4,7 @@ query($flowRunId: uuid, $taskIds: _uuid) {
     task {
       task_runs(where: { flow_run_id: { _eq: $flowRunId } }) {
         id
+        map_index
         version
       }
     }

--- a/src/pages/FlowRun/Restart-Dialog.vue
+++ b/src/pages/FlowRun/Restart-Dialog.vue
@@ -57,7 +57,10 @@ export default {
             })
           )
           .flat()
-          .filter(x => x)
+          // the above flat map doesn't always return objects
+          // but can return something like [undefined, {...}, undefined]
+          // so we filter falsey values here
+          .filter(x => !!x)
 
         let result
         if (taskRunStates?.length > 0) {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
Closes #182 

This PR adds some nuance to the restart from failed button: in particular, because our utility call that traverses the Flow is based on _task_ IDs, we were previously incorrectly resetting the state of mapped pipelines that had partially succeeded.  This PR fixes that by handling mapped pipelines in a special way: if there is a map_index present on the run, we explicitly check if it was a failure, otherwise we don't need to reset its state.