### PR TITLE
Some more GraphQL cleanup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Remove deprecated route calls from Task Concurrency page - [#193](https://github.com/PrefectHQ/ui/pull/193)
 
 ### Bugfixes
 

--- a/src/graphql/TaskTagLimit/task-tag-limit.gql
+++ b/src/graphql/TaskTagLimit/task-tag-limit.gql
@@ -1,7 +1,7 @@
 query TaskTagLimit {
-  task_tag_limit {
+  task_concurrency_limit {
     id
     limit
-    tag
+    name
   }
 }

--- a/src/graphql/TaskTagUsage/task-tag-usage.gql
+++ b/src/graphql/TaskTagUsage/task-tag-usage.gql
@@ -1,6 +1,6 @@
 query TaskTagUsage($tags: [String!]) {
-  task_tag_usage(tags: $tags) {
-    tag
+  task_concurrency(names: $tags) {
+    name
     usage
   }
 }

--- a/src/pages/TeamSettings/TaskConcurrency.vue
+++ b/src/pages/TeamSettings/TaskConcurrency.vue
@@ -220,7 +220,7 @@ export default {
         const res = await this.$apollo.mutate({
           mutation: require('@/graphql/TaskTagLimit/update-task-concurrency-limit.gql'),
           variables: {
-            name: this.selectedTag.tag,
+            name: this.selectedTag.name,
             limit: Number(this.newLimit) // The API expects a type Number, so explicitly casting
           }
         })
@@ -435,7 +435,7 @@ export default {
           </template>
 
           <template v-slot:item.tag="{ item }">
-            <div class="body-2">{{ item.tag }}</div>
+            <div class="body-2">{{ item.name }}</div>
           </template>
 
           <template v-slot:item.usage="{ item }">
@@ -566,7 +566,7 @@ export default {
       v-model="showEditDialog"
       :dialog-props="{ maxWidth: '540' }"
       :title="
-        `Edit the concurrency limit for tasks with the tag ${selectedTag.tag}`
+        `Edit the concurrency limit for tasks with the tag ${selectedTag.name}`
       "
       :disabled="!editValid"
       @confirm="updateTaskTagLimit"
@@ -592,7 +592,7 @@ export default {
       :dialog-props="{ maxWidth: '440' }"
       :title="
         `Are you sure you want to remove concurrency limits for tasks with the
-          tag ${selectedTag.tag}?`
+          tag ${selectedTag.name}?`
       "
       type="error"
       @confirm="deleteTaskTagLimit"

--- a/src/pages/TeamSettings/TaskConcurrency.vue
+++ b/src/pages/TeamSettings/TaskConcurrency.vue
@@ -138,7 +138,7 @@ export default {
     tagsWithUsage() {
       return this.tags.map(tag => ({
         ...tag,
-        usage: this.usage[tag.tag] || 0
+        usage: this.usage[tag.name] || 0
       }))
     }
   },
@@ -153,14 +153,14 @@ export default {
     this.$apollo.addSmartQuery('usage', {
       query: require('@/graphql/TaskTagUsage/task-tag-usage.gql'),
       variables: {
-        tags: this.tags?.map(tag => tag.tag)
+        tags: this.tags?.map(tag => tag.name)
       },
       pollInterval: 5000,
       update: data => {
-        // Usage is returned as an array of objects in format { tag, usage }
+        // Usage is returned as an array of objects in format { name, usage }
         // Convert this array into object that maps tag names to usage
-        return data?.task_tag_usage?.reduce((accum, usage) => {
-          accum[usage.tag] = usage.usage
+        return data?.task_concurrency?.reduce((accum, usage) => {
+          accum[usage.name] = usage.usage
           return accum
         }, {})
       }
@@ -270,7 +270,7 @@ export default {
       query: require('@/graphql/TaskTagLimit/task-tag-limit.gql'),
       pollInterval: 5000,
       loadingKey: 'loadingKey',
-      update: data => data.task_tag_limit,
+      update: data => data.task_concurrency_limit,
       skip() {
         // Skip this query if the tenant isn't eligible
         return !this.isEligible


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
References to task _tags_ are deprecated in the GraphQL API; this PR replaces the deprecated queries with the now supported queries.  The biggest change to take note of is the fact that the database stores these limits by `name`, not `tag`.