### PR TITLE
Barchart bugfix VU

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 - Fix BarChart component resize event listener removal - [#212](https://github.com/PrefectHQ/ui/pull/212)
 - Remove all BarChart underscore method and property references - [#212](https://github.com/PrefectHQ/ui/pull/212)
+- Fix visual bugs associated with resizing while the BarChart component wasn't visible - [#216](https://github.com/PrefectHQ/ui/pull/216)
 
 ## 2020-09-08
 

--- a/src/components/Visualizations/BarChart.vue
+++ b/src/components/Visualizations/BarChart.vue
@@ -18,6 +18,7 @@ export default {
     normalize: { type: Boolean, default: () => true },
     padding: { type: Number, default: () => 2 },
     showControls: { type: Boolean, default: () => false },
+    visible: { type: Boolean, default: () => true },
     width: { type: Number, default: () => null },
     yField: { type: String, default: () => null }
   },
@@ -76,7 +77,7 @@ export default {
     resizeChart: function() {
       return debounce(() => {
         requestAnimationFrame(this.rawResizeChart)
-      }, 150)
+      }, 300)
     },
     min() {
       return this.chartHeight * 0.15
@@ -97,7 +98,7 @@ export default {
   watch: {
     breaklines: debounce(function() {
       if (!this.chart) this.createChart()
-      if (this.loading) return
+      if (this.loading || !this.visible) return
       this.updateBreaklines()
     }, 500),
     items: {
@@ -111,6 +112,11 @@ export default {
     },
     restrictOutliers() {
       this.updateChart()
+    },
+    visible(val) {
+      if (val) {
+        this.resizeChart()
+      }
     }
   },
   mounted() {
@@ -368,22 +374,20 @@ export default {
 
       this.boundingClientRect = this.$refs['parent'].getBoundingClientRect()
 
-      this.chartWidth = this.vertical
+      const width = this.vertical
         ? this.width
         : parent._groups[0][0].clientWidth - paddingLeft - paddingRight
 
-      this.chartHeight = this.vertical
+      const height = this.vertical
         ? parent._groups[0][0].clientHeight - paddingTop - paddingBottom
         : this.height
 
-      if (
-        !this.chartHeight ||
-        !this.chartWidth ||
-        this.chartHeight < 0 ||
-        this.chartWidth < 0
-      ) {
+      if (!height || !width || height <= 0 || width <= 0) {
         return
       }
+
+      this.chartWidth = width
+      this.chartHeight = height
 
       this.chart
         .attr('viewbox', `0 0 ${this.chartWidth} ${this.chartHeight}`)
@@ -506,6 +510,7 @@ export default {
         return
       }
 
+      if (!this.visible) return
       if (!this.computedItems) return
       if (!this.loading) clearTimeout(this.loadingInterval)
 

--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -260,7 +260,10 @@ export default {
             class="my-2"
             tile
           >
-            <TimelineTile :project-id="projectId" />
+            <TimelineTile
+              :project-id="projectId"
+              :visible="tab == 'overview'"
+            />
           </v-skeleton-loader>
 
           <v-skeleton-loader

--- a/src/pages/Dashboard/Timeline-Tile.vue
+++ b/src/pages/Dashboard/Timeline-Tile.vue
@@ -13,7 +13,8 @@ export default {
     projectId: {
       type: String,
       default: () => null
-    }
+    },
+    visible: { type: Boolean, default: () => true }
   },
   data() {
     return {
@@ -80,6 +81,7 @@ export default {
       :height="150"
       :min-bands="100"
       show-controls
+      :visible="visible"
       y-field="duration"
       @bar-click="_barClick"
       @bar-mouseout="_barMouseout"

--- a/src/pages/Flow/Flow.vue
+++ b/src/pages/Flow/Flow.vue
@@ -309,6 +309,7 @@ export default {
             slot="row-0"
             :aggregate="!flowVersionId"
             :flow="selectedFlow"
+            :visible="tab == 'overview'"
           />
 
           <DetailsTile

--- a/src/pages/Flow/Timeline-Tile.vue
+++ b/src/pages/Flow/Timeline-Tile.vue
@@ -17,7 +17,8 @@ export default {
     flow: {
       required: true,
       type: Object
-    }
+    },
+    visible: { type: Boolean, default: () => true }
   },
   data() {
     return {
@@ -102,6 +103,7 @@ export default {
       :height="100"
       :min-bands="100"
       show-controls
+      :visible="visible"
       y-field="duration"
       @bar-click="_barClick"
       @bar-mouseout="_barMouseout"


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds an optional `visible` prop to the `BarChart` component, which prevents resize and update handlers from firing when set to false. FIxes instances where timeline tiles end up in states like this:

![Screen Shot 2020-09-10 at 5 53 04 PM](https://user-images.githubusercontent.com/27291717/92813181-ba04be00-f38e-11ea-99b7-064188d1070a.png)


cc @TylerWanner 