### PR TITLE
Remove task runs from the upcoming runs query

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Features and Improvements
 
 - Fix app-wide component teardown by manually nulling references that were preventing the garbage colector from running correctly - [#212](https://github.com/PrefectHQ/ui/pull/212)
+- Remove `task_run` join from the Dashboard-level Upcoming Runs query - [#218](https://github.com/PrefectHQ/ui/pull/218)
 
 ### Bugfixes
 

--- a/src/graphql/Dashboard/upcoming-flow-runs.gql
+++ b/src/graphql/Dashboard/upcoming-flow-runs.gql
@@ -16,9 +16,5 @@ query UpcomingFlowRuns($projectId: uuid) {
       name
       schedule
     }
-    task_runs {
-      id
-      version
-    }
   }
 }


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Removes the `task_runs` join from the Dashboard `upcoming-flow-runs` query since it's unused and is an expensive join. (This should have been included in the most recent performance PR, not sure how it got removed)