### PR TITLE
Clear late runs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Fix BarChart component resize event listener removal - [#212](https://github.com/PrefectHQ/ui/pull/212)
 - Remove all BarChart underscore method and property references - [#212](https://github.com/PrefectHQ/ui/pull/212)
 - Fix visual bugs associated with resizing while the BarChart component wasn't visible - [#216](https://github.com/PrefectHQ/ui/pull/216)
+- Fix bug preventing late runs from being cleared in the UI - [#227](https://github.com/PrefectHQ/ui/pull/227)
 
 ## 2020-09-08
 

--- a/src/mixins/cancelLateRunsMixin.js
+++ b/src/mixins/cancelLateRunsMixin.js
@@ -86,31 +86,9 @@ export const cancelLateRunsMixin = {
               }
             ) {
               states {
-                id
                 status
               }
             }
-
-            set_task_run_states(
-              input: {
-                states: [${this.individualRuns.map(r =>
-                  r.task_runs.map(t => {
-                    return `{
-                      task_run_id: "${t.id}",
-                      state: ${JSON.stringify(
-                        '{"type": "Cancelled","message": "This run was late and so was cancelled from the UI."}'
-                      )},
-                      version: ${t.version}
-                    }`
-                  })
-                )}]
-              }
-            ) {
-              states {
-                id
-              }
-            }
-          
           `
 
           // Build mutation to delete late flow runs.


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR fixes a minor bug that prevented users from clearing late runs from many of the dashboard pages.  In particular, it seemed our "Clear" button was also attempting to update all task run states to "Cancelled".  On some pages, this piece of the mutation generation was erroring out because there were no referenceable task runs around.

While this is nice, it's not necessary and also could result in performance issues for flows with 100s or 1,000s of tasks.  This PR only updates the flow run state to "Cancelled", which conveniently resolves the bug we were seeing.