### PR TITLE
Set a limit of 100 agents returned from the agents query

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Limit number of agents returned to 100 as a stopgap for runaway registrations - [#230](https://github.com/PrefectHQ/ui/pull/230)
 
 ## 2020-09-15
 

--- a/src/graphql/Agent/agents.gql
+++ b/src/graphql/Agent/agents.gql
@@ -1,5 +1,5 @@
 query Agents {
-  agents {
+  agents(limit: 100) {
     id
     core_version
     name


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Caps the number of agents we query for as a stopgap for runaway registrations.