### PR TITLE
BUGFIX: Flow concurrency usage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,11 +5,10 @@
 ### Features and Improvements
 
 - Add unit tests for tenant store [#195](https://github.com/PrefectHQ/ui/pull/195)
-- None
 
 ### Bugfixes
 
-- None
+- Fix a race condition with flow concurrency usage - [#231](https://github.com/PrefectHQ/ui/pull/231)
 
 ## 2020-09-15
 

--- a/src/pages/TeamSettings/FlowConcurrency.vue
+++ b/src/pages/TeamSettings/FlowConcurrency.vue
@@ -132,23 +132,6 @@ export default {
       this.$apollo?.queries?.usage?.refetch()
     }
   },
-  mounted() {
-    this.$apollo.addSmartQuery('usage', {
-      query: require('@/graphql/FlowLabelUsage/flow-label-usage.gql'),
-      variables: {
-        labels: this.labels?.map(label => label.name)
-      },
-      pollInterval: 5000,
-      update: data => {
-        // Usage is returned as an array of objects in format { name, usage }
-        // Convert this array into object that maps label names to usage
-        return data?.flow_concurrency?.reduce((accum, usage) => {
-          accum[usage.label] = usage.usage
-          return accum
-        }, {})
-      }
-    })
-  },
   methods: {
     async addFlowLabelLimit() {
       try {
@@ -253,7 +236,27 @@ export default {
       query: require('@/graphql/FlowLabelLimit/flow-label-limit.gql'),
       pollInterval: 5000,
       loadingKey: 'loadingKey',
-      update: data => data.flow_concurrency_limit
+      update: data => {
+        return data.flow_concurrency_limit
+      }
+    },
+    usage: {
+      query: require('@/graphql/FlowLabelUsage/flow-label-usage.gql'),
+      variables() {
+        return { labels: this.labels?.map(label => label.name) }
+      },
+      pollInterval: 5000,
+      skip() {
+        return !this.labels?.length
+      },
+      update: data => {
+        // Usage is returned as an array of objects in format { name, usage }
+        // Convert this array into object that maps label names to usage
+        return data?.flow_concurrency?.reduce((accum, usage) => {
+          accum[usage.label] = usage.usage
+          return accum
+        }, {})
+      }
     }
   }
 }


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes a race condition where the flow label usage query was added on mounted with no variables if labels hadn't returned in time. Instead put it in the apollo block with a skip clause for no labels.