### PR TITLE
Improve the way we clear the Apollo InMemoryCache

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script>
 import Alert from '@/components/Alert'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
-import { stopDefaultClient, refreshDefaultClient } from '@/vue-apollo'
+import { clearCache } from '@/vue-apollo'
 import moment from 'moment'
 import NavBar from '@/components/NavBar'
 import SideNav from '@/components/SideNav'
@@ -70,10 +70,8 @@ export default {
       }, 3000)
     },
     async connected(val) {
-      if (!val) {
-        stopDefaultClient()
-      } else {
-        refreshDefaultClient()
+      if (val) {
+        clearCache()
       }
     },
     tenant(val) {

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -4,7 +4,7 @@ import moment from 'moment-timezone'
 import { handleMembershipInvitations } from '@/mixins/membershipInvitationMixin'
 import AcceptConfirmInputRow from '@/components/AcceptConfirmInputRow'
 import Feedback from '@/components/Feedback'
-import { stopDefaultClient, refreshDefaultClient } from '@/vue-apollo'
+import { clearCache } from '@/vue-apollo'
 
 const UI_DEPLOY_TIMESTAMP = process.env.VUE_APP_RELEASE_TIMESTAMP
 
@@ -156,8 +156,6 @@ export default {
     async _switchBackend() {
       this.loading = true
 
-      stopDefaultClient()
-
       if (!this.isCloud) {
         await this.switchBackend('CLOUD')
       } else {
@@ -166,7 +164,7 @@ export default {
 
       this.loading = false
 
-      refreshDefaultClient()
+      clearCache()
       this.handlePostTokenRouting()
     },
     getRoute(name) {
@@ -181,7 +179,6 @@ export default {
     },
     async handleSwitchTenant(tenant) {
       this.loading = true
-      stopDefaultClient()
 
       if (tenant.slug == this.tenant.slug) return
 
@@ -189,7 +186,8 @@ export default {
 
       this.loading = false
       this.tenantMenuOpen = false
-      refreshDefaultClient()
+
+      clearCache()
       this.handlePostTokenRouting()
     },
     handlePostTokenRouting() {

--- a/src/vue-apollo.js
+++ b/src/vue-apollo.js
@@ -308,13 +308,8 @@ export const createApolloProvider = () => {
   return apolloProvider
 }
 
-export const stopDefaultClient = () => {
-  defaultApolloClient.stop()
-}
-
-export const refreshDefaultClient = () => {
-  defaultApolloClient.stop()
-  defaultApolloClient.resetStore()
+export const clearCache = () => {
+  defaultApolloClient.cache.reset()
 }
 
 export const defaultApolloProvider = createApolloProvider()


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Removes the `stopDefaultClient` and `refreshDefaultClient` methods, replacing them with a single `clearCache` method. This should remove invariant store violation errors and allow proper refetches when swapping tokens. 

cc: @zhen0 