### PR TITLE
Log times

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,7 @@
 
 ### Bugfixes
 
-- None
+- Add 24 hour clock to the logs row [#247](https://github.com/PrefectHQ/ui/pull/247)
 
 ## 2020-09-17
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Add 24 hour clock to the logs row [#247](https://github.com/PrefectHQ/ui/pull/247)
 
 ## 2020-09-23
 
@@ -24,7 +24,7 @@
 
 ### Bugfixes
 
-- Add 24 hour clock to the logs row [#247](https://github.com/PrefectHQ/ui/pull/247)
+- None
 
 ## 2020-09-17
 

--- a/src/components/LogsCard/LogRow.vue
+++ b/src/components/LogsCard/LogRow.vue
@@ -1,5 +1,7 @@
 <script>
+import { formatTime } from '@/mixins/formatTimeMixin'
 export default {
+  mixins: [formatTime],
   props: {
     index: {
       type: Number,
@@ -112,7 +114,7 @@ export default {
             {{ log.time }}
           </div>
         </template>
-        <span>{{ log.date }} at {{ log.time }}</span>
+        <span>{{ logDate(log.timestamp) }}</span>
       </v-tooltip>
       <div class="log-level d-flex align-center justify-start">
         <v-icon :color="logLevelColor(log.level)" x-small>lens</v-icon>

--- a/src/components/LogsCard/LogRow.vue
+++ b/src/components/LogsCard/LogRow.vue
@@ -111,7 +111,7 @@ export default {
       <v-tooltip top>
         <template v-slot:activator="{ on }">
           <div class="log-datetime grey--text text--darken-1" v-on="on">
-            {{ log.time }}
+            {{ logTime(log.timestamp) }}
           </div>
         </template>
         <span>{{ logDate(log.timestamp) }}</span>

--- a/src/mixins/formatTimeMixin.js
+++ b/src/mixins/formatTimeMixin.js
@@ -61,6 +61,31 @@ export const formatTime = {
           : moment(timestamp).format('D MMM YYYY h:mma')
       }`
     },
+    formTime(timestamp) {
+      if (!timestamp) return
+      let timeObj = moment(timestamp).tz(this.timezone)
+      return `${
+        timeObj ? timeObj.format('hh:mma') : moment(timestamp).format('hh:mma')
+      }`
+    },
+    logTime(timestamp) {
+      if (!timestamp) return
+      let timeObj = moment(timestamp).tz(this.timezone)
+      return `${
+        timeObj
+          ? timeObj.format('h:mm:ssa')
+          : moment(timestamp).format('h:mm:ssa')
+      }`
+    },
+    logDate(timestamp) {
+      if (!timestamp) return
+      let timeObj = moment(timestamp).tz(this.timezone)
+      return `${
+        timeObj
+          ? timeObj.format('D MMMM YYYY h:mma')
+          : moment(timestamp).format('D MMMM YYYY h:mma')
+      }`
+    },
     formatTime(timestamp) {
       if (!timestamp) return
       let timeObj = moment(timestamp).tz(this.timezone)

--- a/src/mixins/formatTimeMixin.js
+++ b/src/mixins/formatTimeMixin.js
@@ -73,8 +73,8 @@ export const formatTime = {
       let timeObj = moment(timestamp).tz(this.timezone)
       return `${
         timeObj
-          ? timeObj.format('h:mm:ssa')
-          : moment(timestamp).format('h:mm:ssa')
+          ? timeObj.format('HH:mm:ss')
+          : moment(timestamp).format('HH:mm:s')
       }`
     },
     logDate(timestamp) {

--- a/src/mixins/formatTimeMixin.js
+++ b/src/mixins/formatTimeMixin.js
@@ -74,7 +74,7 @@ export const formatTime = {
       return `${
         timeObj
           ? timeObj.format('HH:mm:ss')
-          : moment(timestamp).format('HH:mm:s')
+          : moment(timestamp).format('HH:mm:ss')
       }`
     },
     logDate(timestamp) {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- Uses the format time and log timestamp to add a 24 hour clock on the logs page.  Also adds am/pm to the tooltip (which includes date)
- Closes #134 