### PR TITLE
remove links to Cloud tutorials in server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- - Remove link to Cloud tutorials from Server [#255](https://github.com/PrefectHQ/ui/pull/255)
 
 ## 2020-09-24
 

--- a/src/components/Agents/Agents.vue
+++ b/src/components/Agents/Agents.vue
@@ -323,16 +323,18 @@ export default {
           rel="noopener noreferrer"
           >agents</a
         >
-        to understand their role in your infrastructure. You can also go through
-        the
-        <router-link class="link" :to="{ name: 'flow-run-tutorial' }">
-          <u>Running a Flow</u>
-        </router-link>
-        and
-        <router-link class="link" :to="{ name: 'universal-deploy-tutorial' }">
-          <u>Universal Deploy</u>
-        </router-link>
-        tutorials for guidance on running agents in Cloud.
+        to understand their role in your infrastructure.
+        <span v-if="isCloud">
+          You can also go through the
+          <router-link class="link" :to="{ name: 'flow-run-tutorial' }">
+            <u>Running a Flow</u>
+          </router-link>
+          and
+          <router-link class="link" :to="{ name: 'universal-deploy-tutorial' }">
+            <u>Universal Deploy</u>
+          </router-link>
+          tutorials for guidance on running agents in Cloud.</span
+        >
       </p>
     </v-alert>
   </div>

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -458,6 +458,7 @@ export default {
 
         <v-list dense>
           <v-list-item
+            v-if="isCloud"
             id="tutorial"
             active-class="primary-active-class"
             :disabled="routeDisabled"
@@ -470,6 +471,7 @@ export default {
               <v-list-item-title>Tutorials</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
+
           <v-list-item
             class="bottom"
             ripple


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- Hides the link to tutorials in Server.  Both tutorials are relevant only to Prefect Cloud so are potentially confusing in Server. 