### PR TITLE
BUGFIX: User invitations with unlimited accounts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fixes instances where allowed users and allowed read only users weren't always being read correctly when license terms were null - [#260](https://github.com/PrefectHQ/ui/pull/260)
 
 ## 2020-09-28
 

--- a/src/pages/TeamSettings/Members.vue
+++ b/src/pages/TeamSettings/Members.vue
@@ -82,10 +82,10 @@ export default {
     ...mapGetters('user', ['user']),
     ...mapGetters('license', ['license']),
     allowedFullUsers() {
-      return this.license?.terms?.users
+      return this.license?.terms?.users ?? Infinity
     },
     allowedReadOnlyUsers() {
-      return this.license?.terms?.read_only_users
+      return this.license?.terms?.read_only_users ?? Infinity
     },
     insufficientUsers() {
       return (


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes instances where allowed users and allowed read only users weren't always being read correctly when license terms were null (i.e. a license permitted unlimited users). 