### PR TITLE
Remove "A nonexistant user" from flow and flow run details for server instances

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Don't display nonexistant user info for flows and flow runs when connected to Prefect Server [#269](https://github.com/PrefectHQ/ui/pull/269)
 
 ### Bugfixes
 

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -98,7 +98,7 @@ export default {
       )
     },
     hasUser() {
-      return this.flow.created_by != null
+      return this.flow?.created_by
     }
   },
   methods: {
@@ -274,9 +274,8 @@ export default {
               <div v-if="hasUser" class="subtitle-2">
                 {{ flow.created_by.username }}
               </div>
-              <div class="caption">
-                <b v-if="!hasUser"> {{ formatTime(flow.created) }} </b>
-                <span v-if="hasUser"> {{ formatTime(flow.created) }} </span>
+              <div class="caption" :class="{ 'font-weight-bold': !hasUser }">
+                {{ formatTime(flow.created) }}
               </div>
             </v-list-item-content>
           </v-list-item>

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -266,15 +266,18 @@ export default {
     <v-card-text class="pl-12 pt-2 card-content">
       <v-fade-transition hide-on-leave>
         <div v-if="tab == 'overview'">
-          <v-list-item v-if="hasUser" dense class="px-0">
+          <v-list-item dense class="px-0">
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
-                Created by
+                Created <span v-if="hasUser">by</span>
               </v-list-item-subtitle>
-              <div class="subtitle-2">
+              <div v-if="hasUser" class="subtitle-2">
                 {{ flow.created_by.username }}
               </div>
-              <div class="caption">{{ formatTime(flow.created) }} </div>
+              <div class="caption">
+                <b v-if="!hasUser"> {{ formatTime(flow.created) }} </b>
+                <span v-if="hasUser"> {{ formatTime(flow.created) }} </span>
+              </div>
             </v-list-item-content>
           </v-list-item>
 

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -96,6 +96,9 @@ export default {
           (val, index) => val === this.flow?.environment?.labels[index]
         )
       )
+    },
+    hasUser() {
+      return this.flow.created_by != null
     }
   },
   methods: {
@@ -263,7 +266,7 @@ export default {
     <v-card-text class="pl-12 pt-2 card-content">
       <v-fade-transition hide-on-leave>
         <div v-if="tab == 'overview'">
-          <v-list-item dense class="px-0">
+          <v-list-item v-if="hasUser" dense class="px-0">
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Created by

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -272,11 +272,7 @@ export default {
                 Created by
               </v-list-item-subtitle>
               <div class="subtitle-2">
-                {{
-                  flow.created_by
-                    ? flow.created_by.username
-                    : 'A nonexistent user'
-                }}
+                {{ flow.created_by.username }}
               </div>
               <div class="caption">{{ formatTime(flow.created) }} </div>
             </v-list-item-content>

--- a/src/pages/FlowRun/Details-Tile.vue
+++ b/src/pages/FlowRun/Details-Tile.vue
@@ -30,6 +30,9 @@ export default {
     hasParameters() {
       if (!this.flowRun?.parameters) return false
       return Object.keys(this.flowRun.parameters).length > 0
+    },
+    hasUserOrIsAutoscheduled() {
+      return this.flowRun.created_by != null || this.flowRun.auto_scheduled
     }
   },
   methods: {
@@ -135,7 +138,7 @@ export default {
     <v-card-text class="pl-12 card-content">
       <v-fade-transition hide-on-leave>
         <div v-if="tab === 'overview'">
-          <v-list-item dense class="px-0">
+          <v-list-item v-if="hasUserOrIsAutoscheduled" class="px-0">
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Created by
@@ -144,9 +147,7 @@ export default {
                 {{
                   flowRun.auto_scheduled
                     ? 'Prefect Scheduler'
-                    : flowRun.created_by
-                    ? flowRun.created_by.username
-                    : 'Ad hoc run'
+                    : flowRun.created_by.username
                 }}
               </div>
             </v-list-item-content>

--- a/src/pages/FlowRun/Details-Tile.vue
+++ b/src/pages/FlowRun/Details-Tile.vue
@@ -146,7 +146,7 @@ export default {
                     ? 'Prefect Scheduler'
                     : flowRun.created_by
                     ? flowRun.created_by.username
-                    : 'A nonexistant user'
+                    : 'Ad hoc run'
                 }}
               </div>
             </v-list-item-content>

--- a/src/pages/FlowRun/Details-Tile.vue
+++ b/src/pages/FlowRun/Details-Tile.vue
@@ -3,6 +3,7 @@ import jsBeautify from 'js-beautify'
 import { formatTime } from '@/mixins/formatTimeMixin'
 import CardTitle from '@/components/Card-Title'
 import DurationSpan from '@/components/DurationSpan'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -22,6 +23,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters('api', ['isCloud']),
     hasContext() {
       return (
         this.flowRun.context && Object.keys(this.flowRun.context).length > 0
@@ -31,8 +33,8 @@ export default {
       if (!this.flowRun?.parameters) return false
       return Object.keys(this.flowRun.parameters).length > 0
     },
-    hasUserOrIsAutoscheduled() {
-      return this.flowRun.created_by != null || this.flowRun.auto_scheduled
+    isCloudOrAutoScheduled() {
+      return this.isCloud || this.flowRun?.auto_scheduled
     }
   },
   methods: {
@@ -138,7 +140,7 @@ export default {
     <v-card-text class="pl-12 card-content">
       <v-fade-transition hide-on-leave>
         <div v-if="tab === 'overview'">
-          <v-list-item v-if="hasUserOrIsAutoscheduled" class="px-0">
+          <v-list-item v-if="isCloudOrAutoScheduled" class="px-0">
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Created by
@@ -147,7 +149,9 @@ export default {
                 {{
                   flowRun.auto_scheduled
                     ? 'Prefect Scheduler'
-                    : flowRun.created_by.username
+                    : flowRun.created_by
+                    ? flowRun.created_by.username
+                    : 'A nonexistant user'
                 }}
               </div>
             </v-list-item-content>


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR

Currently all flows and subsequent runs for server users show that they are created by `A nonexistant user` and this is not helpful or could be confusing to users of server because the backend has no concept of users. This PR updates the flow details tile to only display this section if a user is attached to a flow and it updates the text output of the flow run details tile.

**Flow**

Before:
![image](https://user-images.githubusercontent.com/40716964/94621438-4b749b00-027e-11eb-8c39-6d866ad71a58.png)

After:
![image](https://user-images.githubusercontent.com/40716964/94622984-2f262d80-0281-11eb-984f-09fd40f47a5f.png)

**Flow Run**

Before:
![image](https://user-images.githubusercontent.com/40716964/94621609-a3130680-027e-11eb-87ec-0491b76e2e45.png)

After:
![image](https://user-images.githubusercontent.com/40716964/94622151-a65ac200-027f-11eb-8fa7-e5204f08b5a0.png)

**Note** this might not be the best wording for an ad hoc / manually created run. Open to suggestions!