### PR TITLE
Properly redirect to home when server instance has no tenants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Redirect to home when UI is loaded up against a Prefect Server instance with no tenants [#270](https://github.com/PrefectHQ/ui/pull/270)
 
 ## 2020-09-29
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -181,7 +181,7 @@ export default {
         await this.getTenants()
 
         if (this.isServer && !this.tenants?.length) {
-          // Server has no tenants so so redirect to home
+          // Server has no tenants so redirect to home
           this.$router.push({
             name: 'home'
           })

--- a/src/App.vue
+++ b/src/App.vue
@@ -180,6 +180,13 @@ export default {
         await this.getApi()
         await this.getTenants()
 
+        if (this.isServer && !this.tenants?.length) {
+          // Server has no tenants so so redirect to home
+          this.$router.push({
+            name: 'home'
+          })
+        }
+
         if (this.isServer && this.tenants?.length) {
           // If this is Server, there won't be a default tenant, so we'll set one
           this.setDefaultTenant(this.tenants?.[0])

--- a/src/App.vue
+++ b/src/App.vue
@@ -182,9 +182,11 @@ export default {
 
         if (this.isServer && !this.tenants?.length) {
           // Server has no tenants so redirect to home
-          this.$router.push({
-            name: 'home'
-          })
+          if (this.$route.name !== 'home') {
+            this.$router.push({
+              name: 'home'
+            })
+          }
         }
 
         if (this.isServer && this.tenants?.length) {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR

Currently when spinning up the UI to look at the Prefect Server with no tenants it loads a blank dashboard:

![image](https://user-images.githubusercontent.com/40716964/94624275-0d7a7580-0284-11eb-85f2-8c2b6a004394.png)

This PR fixes this by redirecting to the home page where more information is present on how to create a tenant.