### PR TITLE
Allow label editing on older versions of core and disable empty entries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Allow label edit on flows created with an older version of core [#273](https://github.com/PrefectHQ/ui/pull/273)
 
 ## 2020-09-29
 

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -83,7 +83,8 @@ export default {
       const labels =
         this.newLabels ||
         this.flowGroup?.labels ||
-        this.flow?.environment?.labels
+        this.flow?.environment?.labels ||
+        []
       return labels?.slice().sort()
     },
     labelResetDisabled() {
@@ -123,6 +124,7 @@ export default {
     },
     addLabel() {
       if (!this.valid) return
+      if (!this.newLabel) return
       this.disableAdd = true
       const labelArray = this.newLabels || this.labels.slice()
       labelArray.push(this.newLabel)


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
-Fixes an issue where flows registered with older versions of core (and so had no labels) could not add flow group labels from the UI
- As raised in https://prefect-community.slack.com/archives/C0192RWGJQH/p1601436207001800