### PR TITLE
Cut changelog ahead of 2020-10-05 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,30 +1,40 @@
 # Changelog
 
+
 ## Unreleased
 
 ### Features and Improvements
 
-- Don't display nonexistant user info for flows and flow runs when connected to Prefect Server [#269](https://github.com/PrefectHQ/ui/pull/269)
+- None
 
 ### Bugfixes
 
 - None
 
-## 2020-10-01
+## 2020-10-05
 
 ### Features and Improvements
 
-- Update information in "Connect the UI" section of the home view [#271](https://github.com/PrefectHQ/ui/pull/271)
+- Don't display nonexistant user info for flows and flow runs when connected to Prefect Server [#269](https://github.com/PrefectHQ/ui/pull/269)
 - Add agent ID to flow run page details for submitted runs [#249](https://github.com/PrefectHQ/ui/pull/249)
 - Expose agents page and dashboard tile for server users [#249](https://github.com/PrefectHQ/ui/pull/249)
 - Make labels on agent cards scrollable and add ID to information displayed [#249](https://github.com/PrefectHQ/ui/pull/249)
 
 ### Bugfixes
 
+- Allow IP address as endpoint for URL cloudhooks [#277](https://github.com/PrefectHQ/ui/pull/277)
+
+## 2020-10-01
+
+### Features and Improvements
+
+- Update information in "Connect the UI" section of the home view [#271](https://github.com/PrefectHQ/ui/pull/271)
+
+### Bugfixes
+
 - Make sure the 'To The Dashboard' button is more visible on the onboard/resources page [#275](https://github.com/PrefectHQ/ui/pull/275)
 - Allow label edit on flows created with an older version of core [#273](https://github.com/PrefectHQ/ui/pull/273)
 - Redirect to home when UI is loaded up against a Prefect Server instance with no tenants [#270](https://github.com/PrefectHQ/ui/pull/270)
-- Allow IP address as endpoint for URL cloudhooks [#277](https://github.com/PrefectHQ/ui/pull/277)
 - Direct users to the new tenant when they accept an invitation from the accept invitation page [#274](https://github.com/PrefectHQ/ui/pull/274)
 
 ## 2020-09-29


### PR DESCRIPTION
## 2020-10-05

### Features and Improvements

- Don't display nonexistant user info for flows and flow runs when connected to Prefect Server [#269](https://github.com/PrefectHQ/ui/pull/269)
- Add agent ID to flow run page details for submitted runs [#249](https://github.com/PrefectHQ/ui/pull/249)
- Expose agents page and dashboard tile for server users [#249](https://github.com/PrefectHQ/ui/pull/249)
- Make labels on agent cards scrollable and add ID to information displayed [#249](https://github.com/PrefectHQ/ui/pull/249)

### Bugfixes

- Allow IP address as endpoint for URL cloudhooks [#277](https://github.com/PrefectHQ/ui/pull/277)
