### PR TITLE
Refactor circleCI to inlude a slack notification for prod approvals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,19 +190,9 @@ workflows:
                 - master
   'Deploy prod':
     jobs:
-      - docker/publish:
-          docker-password: DOCKER_HUB_PW
-          docker-username: DOCKER_HUB_USER
-          image: 'prefecthq/ui'
-          path: '.'
-          tag: $CIRCLE_TAG,latest
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/
-      - build-prod:
+      - slack/approval-notification:
+          mentions: "nicholas,chris"
+          message: "Release Prod"
           filters:
             branches:
               ignore:
@@ -217,10 +207,32 @@ workflows:
                 - /.*/
             tags:
               only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/
+      - build-prod:
+          requires:
+            - request-release
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/
+      - docker/publish:
+          requires:
+            - request-release
+          docker-password: DOCKER_HUB_PW
+          docker-username: DOCKER_HUB_USER
+          image: 'prefecthq/ui'
+          path: '.'
+          tag: $CIRCLE_TAG,latest
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])).*/
       - deploy-prod:
           requires:
             - build-prod
-            - request-release
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   docker: circleci/docker@1.0.0
+  slack: circleci/slack@3.4.2
 
 commands:
   prep:

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,16 @@
 
 ### Features and Improvements
 
+- None
+
+### Bugfixes
+
+- None
+
+## 2020-10-01
+
+### Features and Improvements
+
 - Update information in "Connect the UI" section of the home view [#271](https://github.com/PrefectHQ/ui/pull/271)
 
 ### Bugfixes


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
No code changes, but this PR refactors our prod deployment jobs just a tiny bit:
- pings @znicholasbrown and myself for approval notifications
- only builds / publishes images _post_ approval