### PR TITLE
Apollo url speed racer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## Unreleased
 
 ### Features and Improvements
@@ -9,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix race condition with `apollo_url` - [#295](https://github.com/PrefectHQ/ui/pull/295)
 
 ## 2020-10-05
 

--- a/public/index.html
+++ b/public/index.html
@@ -48,18 +48,6 @@
       async
     ></script>
     <script src="https://js.stripe.com/v3/" async></script>
-
-    <script>
-      ;(async () => {
-        try {
-          window.prefect_ui_settings = await fetch('/settings.json')
-            .then(response => response.json())
-            .then(data => data)
-        } catch {
-          // Let this fail silently
-        }
-      })()
-    </script>
   </head>
   <body>
     <noscript>

--- a/src/main.js
+++ b/src/main.js
@@ -262,8 +262,6 @@ const initialize = async () => {
       apolloProvider: defaultApolloProvider,
       render: h => h(App)
     }).$mount('#app')
-
-    console.log(window.prefect_ui_settings)
   }
 }
 initialize()

--- a/src/main.js
+++ b/src/main.js
@@ -243,15 +243,30 @@ Vue.mixin({
   }
 })
 
-// Create application
-// eslint-disable-next-line no-unused-vars
-let PrefectUI = new Vue({
-  vuetify,
-  router,
-  store,
-  apolloProvider: defaultApolloProvider,
-  render: h => h(App)
-}).$mount('#app')
+let PrefectUI
+
+const initialize = async () => {
+  try {
+    window.prefect_ui_settings = await fetch('/settings.json')
+      .then(response => response.json())
+      .then(data => data)
+  } finally {
+    // Let this fail silently
+
+    // Create application
+    // eslint-disable-next-line no-unused-vars
+    PrefectUI = new Vue({
+      vuetify,
+      router,
+      store,
+      apolloProvider: defaultApolloProvider,
+      render: h => h(App)
+    }).$mount('#app')
+
+    console.log(window.prefect_ui_settings)
+  }
+}
+initialize()
 
 // This can be used in testing to destroy the entire application and remove
 // the root node associated with it.

--- a/src/pages/Home/StartPrefectServer-Section.vue
+++ b/src/pages/Home/StartPrefectServer-Section.vue
@@ -23,14 +23,14 @@ export default {
   methods: {
     ...mapActions('api', ['getApi']),
     ...mapActions('tenant', ['updateTenantSettings']),
-    ...mapMutations('api', ['setServerUrl']),
+    ...mapMutations('api', ['setServerUrl', 'unsetServerUrl']),
     _handleKeyup() {
       this.success = false
       this.error = false
       this.loading = false
     },
     async _resetUrl() {
-      localStorage.removeItem('server_url')
+      this.unsetServerUrl()
 
       this.urlInput = this.defaultUrl
 

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -1,6 +1,8 @@
 import { fallbackApolloClient } from '@/vue-apollo'
 import LogRocket from 'logrocket'
 
+const UI_DEPLOY_TIMESTAMP = process.env.VUE_APP_RELEASE_TIMESTAMP
+
 const maxRetries = 3
 
 const state = {
@@ -14,7 +16,7 @@ const state = {
   cloudUrl: process.env.VUE_APP_CLOUD_URL,
   retries: 0,
   serverUrl:
-    localStorage.getItem('server_url') ||
+    localStorage.getItem(`${UI_DEPLOY_TIMESTAMP}_server_url`) ||
     window.prefect_ui_settings?.server_url ||
     process.env.VUE_APP_SERVER_URL,
   version: null
@@ -119,12 +121,12 @@ const mutations = {
     state.retries = retries
   },
   setServerUrl(state, url) {
-    localStorage.setItem('server_url', url)
     state.serverUrl = url
+    localStorage.setItem(`${UI_DEPLOY_TIMESTAMP}_server_url`, url)
   },
   unsetServerUrl(state) {
-    localStorage.removeItem('server_url')
     state.serverUrl = null
+    localStorage.removeItem(`${UI_DEPLOY_TIMESTAMP}_server_url`)
   },
   setVersion(state, version) {
     state.version = version

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -1,11 +1,11 @@
 import { fallbackApolloClient } from '@/vue-apollo'
 import LogRocket from 'logrocket'
 
-const UI_DEPLOY_TIMESTAMP = process.env.VUE_APP_RELEASE_TIMESTAMP
+const SERVER_KEY = `${process.env.VUE_APP_RELEASE_TIMESTAMP}_server_url`
 
-if (!localStorage.getItem(`${UI_DEPLOY_TIMESTAMP}_server_url`)) {
+if (!localStorage.getItem(SERVER_KEY)) {
   localStorage.setItem(
-    `${UI_DEPLOY_TIMESTAMP}_server_url`,
+    SERVER_KEY,
     window.prefect_ui_settings?.server_url || process.env.VUE_APP_SERVER_URL
   )
 }
@@ -22,7 +22,7 @@ const state = {
   apiMode: null,
   cloudUrl: process.env.VUE_APP_CLOUD_URL,
   retries: 0,
-  serverUrl: localStorage.getItem(`${UI_DEPLOY_TIMESTAMP}_server_url`),
+  serverUrl: localStorage.getItem(SERVER_KEY),
   version: null
 }
 
@@ -126,11 +126,11 @@ const mutations = {
   },
   setServerUrl(state, url) {
     state.serverUrl = url
-    localStorage.setItem(`${UI_DEPLOY_TIMESTAMP}_server_url`, url)
+    localStorage.setItem(SERVER_KEY, url)
   },
   unsetServerUrl(state) {
     state.serverUrl = null
-    localStorage.removeItem(`${UI_DEPLOY_TIMESTAMP}_server_url`)
+    localStorage.removeItem(SERVER_KEY)
   },
   setVersion(state, version) {
     state.version = version

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -3,6 +3,13 @@ import LogRocket from 'logrocket'
 
 const UI_DEPLOY_TIMESTAMP = process.env.VUE_APP_RELEASE_TIMESTAMP
 
+if (!localStorage.getItem(`${UI_DEPLOY_TIMESTAMP}_server_url`)) {
+  localStorage.setItem(
+    `${UI_DEPLOY_TIMESTAMP}_server_url`,
+    window.prefect_ui_settings?.server_url || process.env.VUE_APP_SERVER_URL
+  )
+}
+
 const maxRetries = 3
 
 const state = {
@@ -15,10 +22,7 @@ const state = {
   apiMode: null,
   cloudUrl: process.env.VUE_APP_CLOUD_URL,
   retries: 0,
-  serverUrl:
-    localStorage.getItem(`${UI_DEPLOY_TIMESTAMP}_server_url`) ||
-    window.prefect_ui_settings?.server_url ||
-    process.env.VUE_APP_SERVER_URL,
+  serverUrl: localStorage.getItem(`${UI_DEPLOY_TIMESTAMP}_server_url`),
   version: null
 }
 

--- a/tests/unit/store/api.spec.js
+++ b/tests/unit/store/api.spec.js
@@ -3,6 +3,8 @@ import { createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
 jest.useFakeTimers()
 
+const SERVER_KEY = `${process.env.VUE_APP_RELEASE_TIMESTAMP}_server_url`
+
 //simple mock for gql api query
 let mockerror = false
 
@@ -57,7 +59,7 @@ describe('API Vuex Module', () => {
         cloudUrl: process.env.VUE_APP_CLOUD_URL,
         retries: 0,
         serverUrl:
-          localStorage.getItem('server_url') || process.env.VUE_APP_SERVER_URL,
+          localStorage.getItem(SERVER_KEY) || process.env.VUE_APP_SERVER_URL,
         version: null
       }
     }
@@ -79,13 +81,13 @@ describe('API Vuex Module', () => {
         cloudUrl: process.env.VUE_APP_CLOUD_URL,
         retries: 0,
         serverUrl:
-          localStorage.getItem('server_url') || process.env.VUE_APP_SERVER_URL,
+          localStorage.getItem(SERVER_KEY) || process.env.VUE_APP_SERVER_URL,
         version: null
       }
     }
     localStoreAPIState = () => {
       localStorage.setItem('backend', 'foo')
-      localStorage.setItem('server_url', 'http://0.0.0.0:4200/graphql')
+      localStorage.setItem(SERVER_KEY, 'http://0.0.0.0:4200/graphql')
       process.env.VUE_APP_BACKEND = 'CLOUD'
       process.env.VUE_APP_SERVER_URL = 'http://localhost:4200/graphql'
       return {
@@ -101,7 +103,7 @@ describe('API Vuex Module', () => {
         cloudUrl: process.env.VUE_APP_CLOUD_URL,
         retries: 5,
         serverUrl:
-          localStorage.getItem('server_url') || process.env.VUE_APP_SERVER_URL,
+          localStorage.getItem(SERVER_KEY) || process.env.VUE_APP_SERVER_URL,
         version: 8
       }
     }
@@ -318,7 +320,7 @@ describe('API Vuex Module', () => {
         store.commit('setServerUrl', 'http:localhost:4200')
         expect(store.getters['serverUrl']).toEqual('http:localhost:4200')
         expect(localStorage.setItem).toBeCalledWith(
-          'server_url',
+          SERVER_KEY,
           'http:localhost:4200'
         )
       })
@@ -328,7 +330,7 @@ describe('API Vuex Module', () => {
       it('should unset the server url in state and local storage', () => {
         store.commit('unsetServerUrl')
         expect(store.getters['serverUrl']).toEqual(null)
-        expect(localStorage.removeItem).toBeCalledWith('server_url')
+        expect(localStorage.removeItem).toBeCalledWith(SERVER_KEY)
       })
     })
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
Moves the server ui settings out of the index head and into `main.js` as a pre-condition to initializing the Vue app. This should remove the race condition which caused the `apollo_url` setting to sometimes be ignored. 