### PR TITLE
Pluralization bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@
 
 ### Bugfixes
 
-- None
+- Don't pluralize "slot" when only one is being used [#293](https://github.com/PrefectHQ/ui/issues/293)
 
 ## 2020-10-05
 

--- a/src/components/ConcurrencyInfo.vue
+++ b/src/components/ConcurrencyInfo.vue
@@ -31,7 +31,7 @@ export default {
   <div v-if="concurrentRuns && license">
     {{ concurrentRuns.length
     }}{{ flowConcurrency ? `/${flowConcurrency}` : '' }} slot{{
-      flowConcurrency === 1 ? '' : 's'
+      concurrentRuns.length === 1 || flowConcurrency === 1 ? '' : 's'
     }}
     used
 


### PR DESCRIPTION
PR Checklist:

- [X] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes bug in #293 that says "1 slots used", will now be singular if one slot in use or license only allows one slot
