### PR TITLE
Display task run names on flow run page and task run page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 ### Features and Improvements
 
 - Add unit tests for the authNavGuard middleware [#266](https://github.com/PrefectHQ/ui/pull/266)
+- Display task run names on flow run page and task run page [#302](https://github.com/PrefectHQ/ui/pull/302)
 
 ### Bugfixes
 

--- a/src/components/HeartbeatTimeline.vue
+++ b/src/components/HeartbeatTimeline.vue
@@ -77,7 +77,7 @@ export default {
           name = item.name
           break
         case 'task_run':
-          name = item.task.name
+          name = item.name || item.task.name
           break
         case 'task_run_state':
           name = item.message
@@ -183,9 +183,11 @@ export default {
                     <v-icon v-if="item.map_index > -1" x-small class="mx-1"
                       >dynamic_feed</v-icon
                     >
-                    <span v-if="item.map_index > -1" class="text-body-2">{{
-                      item.map_index
-                    }}</span>
+                    <span
+                      v-if="item.map_index > -1 && !item.name"
+                      class="text-body-2"
+                      >{{ item.map_index }}</span
+                    >
                   </div>
 
                   <div v-if="item.state_message" class="text-caption truncate">
@@ -207,7 +209,10 @@ export default {
               <div v-if="type !== 'task_run_state'" class="text-body-1">
                 <router-link class="link" :to="routeTo(item)">
                   {{ timelineItemTitle(item) }}
-                  <span v-if="item.map_index > -1" class="text-caption mb-2">
+                  <span
+                    v-if="item.map_index > -1 && !item.name"
+                    class="text-caption mb-2"
+                  >
                     (Mapped Child {{ item.map_index }})
                   </span>
                 </router-link>

--- a/src/graphql/FlowRun/flow-run.js
+++ b/src/graphql/FlowRun/flow-run.js
@@ -80,6 +80,7 @@ export default function(isCloud) {
             max_retries
             retry_delay
           }
+          name
         }
         flow {
           id

--- a/src/graphql/FlowRun/heartbeat.gql
+++ b/src/graphql/FlowRun/heartbeat.gql
@@ -19,5 +19,6 @@ query Heartbeat($flowRunId: uuid!, $timestamp: timestamptz, $state: String) {
       max_retries
     }
     __typename
+    name
   }
 }

--- a/src/graphql/FlowRun/table-task-runs.gql
+++ b/src/graphql/FlowRun/table-task-runs.gql
@@ -24,6 +24,7 @@ query TableTaskRuns(
         id
         name
       }
+      name
     }
   }
 }

--- a/src/graphql/FlowRun/task-run-drawer.gql
+++ b/src/graphql/FlowRun/task-run-drawer.gql
@@ -21,5 +21,6 @@ query TaskRun($id: uuid!) {
       retry_delay
     }
     version
+    name
   }
 }

--- a/src/graphql/FlowRun/task-runs.gql
+++ b/src/graphql/FlowRun/task-runs.gql
@@ -15,5 +15,6 @@ query TaskRuns(
       name
       mapped
     }
+    name
   }
 }

--- a/src/graphql/Task/activity.gql
+++ b/src/graphql/Task/activity.gql
@@ -31,6 +31,7 @@ query Activity(
       flow_run {
         id
       }
+      name
     }
   }
 }

--- a/src/graphql/TaskRun/task-run.gql
+++ b/src/graphql/TaskRun/task-run.gql
@@ -10,6 +10,7 @@ query TaskRun($id: uuid!) {
     end_time
     map_index
     serialized_state
+    name
 
     task {
       id

--- a/src/pages/FlowRun/TaskRunTable-Tile.vue
+++ b/src/pages/FlowRun/TaskRunTable-Tile.vue
@@ -184,7 +184,8 @@ export default {
                   :data-cy="'task-run-table-link|' + item.task.name"
                   :to="{ name: 'task-run', params: { id: item.id } }"
                 >
-                  <span v-on="on"
+                  <span v-if="item.name">{{ item.name }}</span>
+                  <span v-else v-on="on"
                     >{{ item.task.name
                     }}<span v-if="item.map_index > -1">
                       (Mapped Child {{ item.map_index }})</span

--- a/src/pages/TaskRun/TaskRun.vue
+++ b/src/pages/TaskRun/TaskRun.vue
@@ -128,12 +128,15 @@ export default {
     <SubPageNav>
       <span slot="page-type">Task Run</span>
       <span slot="page-title">
-        {{ taskRun.flow_run.name }} - {{ taskRun.task.name }}
-        <span v-if="taskRun.map_index > -1">
-          (Mapped Child {{ taskRun.map_index }})
+        {{ taskRun.flow_run.name }} -
+        <span v-if="taskRun.name">{{ taskRun.name }}</span>
+        <span v-else>
+          {{ taskRun.task.name }}
+          <span v-if="taskRun.map_index > -1">
+            (Mapped Child {{ taskRun.map_index }})
+          </span>
+          <span v-else-if="parent > 1"> (Parent) </span>
         </span>
-
-        <span v-else-if="parent > 1"> (Parent) </span>
       </span>
       <BreadCrumbs
         slot="breadcrumbs"


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR

Closes #301 

This PR exposes the new task run names if they are set. The task run names on the flow run page and task run page are updated (screenshots below). Here is the flow code used if anyone wants to reproduce:

```python
from prefect import task, Flow

@task
def get_values():
    return ['my_value', 'another_one', 'nicholas', 'marvin']

@task(log_stdout=True, task_run_name=lambda **kwargs: f"{kwargs['v']}")
def compute(v):
    print(v)

with Flow("task_run_names") as flow:
    vals = get_values()
    compute.map(vals)

flow.register(project_name="Demo")
```

_[Flow Run Page]_ Current vs New 

![image](https://user-images.githubusercontent.com/40716964/95473049-b2b2df00-0951-11eb-8539-4a8532cc1117.png)

_[Task Run Page]_ Current vs New

![image](https://user-images.githubusercontent.com/40716964/95473198-dbd36f80-0951-11eb-926f-5ef6aa54bae6.png)

Let me know if there are any more places we should expose this / if my boolean JS logic is correct 🙂 