### PR TITLE
Fix race condition with onboard/welcome flow

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Fix race condition with `apollo_url` - [#295](https://github.com/PrefectHQ/ui/pull/295)
 - Don't pluralize "slot" when only one is being used [#293](https://github.com/PrefectHQ/ui/issues/293)
 - Enable global search for task runs without names [#299](https://github.com/PrefectHQ/ui/pull/299)
+- Fix race condition with onboard/welcome flow [#304](https://github.com/PrefectHQ/ui/pull/304)
 
 ## 2020-10-05
 

--- a/src/vue-apollo.js
+++ b/src/vue-apollo.js
@@ -181,10 +181,10 @@ const authMiddleware = setContext(async (_, { headers }) => {
   if (
     store.getters['api/backend'] !== 'SERVER' &&
     (!store.getters['auth0/idToken'] || !isAuthenticatedUser) &&
-    !store.getters['isRefreshingAuthentication']
+    !store.getters['auth0/isRefreshingAuthentication']
   ) {
     return await store.dispatch('auth0/updateAuthentication')
-  } else if (store.getters['isRefreshingAuthentication']) {
+  } else if (store.getters['auth0/isRefreshingAuthentication']) {
     // Don't fire requests while we're trying to refresh authentication
     return
   }


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes race condition which sometimes prevented users from hitting the onboard/welcome pages when a new tenant was created. Also prevents dashboard flicker when `startup` method hasn't finished in the App component. 