### PR TITLE
use membership id instead of route query for invitation id

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Fix race condition with `apollo_url` - [#295](https://github.com/PrefectHQ/ui/pull/295)
 - Don't pluralize "slot" when only one is being used [#293](https://github.com/PrefectHQ/ui/issues/293)
 - Enable global search for task runs without names [#299](https://github.com/PrefectHQ/ui/pull/299)
+- Fix bug with unknown invitation ID in accept invitation [#306](https://github.com/PrefectHQ/ui/pull/306)
 
 ## 2020-10-05
 

--- a/src/pages/AcceptInvitationPage.vue
+++ b/src/pages/AcceptInvitationPage.vue
@@ -27,7 +27,8 @@ export default {
     async accept() {
       this.loading = true
       const tenant = this.membershipInvitation[0].tenant
-      const accepted = await this.acceptInvitation()
+      const invitationId = this.membershipInvitation[0].id
+      const accepted = await this.acceptInvitation(invitationId)
       if (accepted) {
         await this.setCurrentTenant(tenant.slug)
         this.$router.push({
@@ -36,12 +37,12 @@ export default {
         })
       }
     },
-    async acceptInvitation() {
+    async acceptInvitation(id) {
       try {
         const { data } = await this.$apollo.mutate({
           mutation: require('@/graphql/Tenant/accept-membership-invitation.gql'),
           variables: {
-            membershipInvitationId: this.invitationId
+            membershipInvitationId: id
           }
         })
         if (data?.accept_membership_invitation?.id) {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- Fixes a bug where the invitation ID was not stored long enough to accept an invitation in the accept invitation page