### PR TITLE
Add `Run Config` section to flow details

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Features and Improvements
 
+- Add section to flow details for `flow.run_config` if not null, otherwise display `flow.environment` [#307](https://github.com/PrefectHQ/ui/pull/307)
 - Enable restart from cancelled and update restart from failed[#234](https://github.com/PrefectHQ/ui/pull/234)
 - Add unit tests for the authNavGuard middleware [#266](https://github.com/PrefectHQ/ui/pull/266)
 - Update label edit and label warning to use flow run labels (#300)[https://github.com/PrefectHQ/ui/pull/300]

--- a/src/graphql/Flow/flow.js
+++ b/src/graphql/Flow/flow.js
@@ -29,6 +29,7 @@ export default function(isCloud) {
           }
 
           description
+          run_config
           environment
           flow_group_id
 

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -418,7 +418,23 @@ export default {
           </v-list-item>
 
           <v-list-item dense class="px-0">
-            <v-list-item-content>
+            <v-list-item-content v-if="flow.run_config">
+              <v-list-item-subtitle class="grey--text text--darken-3">
+                Run Config
+              </v-list-item-subtitle>
+              <v-divider style="max-width: 50%;" />
+              <v-list-item-subtitle class="caption">
+                <v-row v-if="flow.run_config.type" no-gutters>
+                  <v-col cols="6">
+                    Type
+                  </v-col>
+                  <v-col cols="6" class="text-right font-weight-bold">
+                    {{ flow.run_config.type }}
+                  </v-col>
+                </v-row>
+              </v-list-item-subtitle>
+            </v-list-item-content>
+            <v-list-item-content v-else>
               <v-list-item-subtitle class="grey--text text--darken-3">
                 Environment
               </v-list-item-subtitle>


### PR DESCRIPTION
For flows configured with a `run_config`, we display the `run_config`
details instead of the environment details. Currently this is only the
`run_config` type. In the future we might expand this to include more
details.

Screenshot:

<img width="459" alt="Screen Shot 2020-10-08 at 4 16 53 PM" src="https://user-images.githubusercontent.com/2783717/95514555-c24a1c00-0981-11eb-865d-ff8fc0e3de08.png">


PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)
