### PR TITLE
Take labels from `flow.run_config` if present

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Features and Improvements
 
+- Use labels from `flow.run_config` if present [#309](https://github.com/PrefectHQ/ui/pull/309)
 - Add section to flow details for `flow.run_config` if not null, otherwise display `flow.environment` [#307](https://github.com/PrefectHQ/ui/pull/307)
 - Enable restart from cancelled and update restart from failed [#234](https://github.com/PrefectHQ/ui/pull/234)
 - Add unit tests for the authNavGuard middleware [#266](https://github.com/PrefectHQ/ui/pull/266)

--- a/src/components/LabelEdit.vue
+++ b/src/components/LabelEdit.vue
@@ -52,6 +52,7 @@ export default {
         this.newLabels ||
         this.flowRun?.labels ||
         this.flowGroup?.labels ||
+        this.flow?.run_config?.labels ||
         this.flow?.environment?.labels ||
         []
       return labels?.slice().sort()
@@ -61,13 +62,13 @@ export default {
     },
     labelResetDisabled() {
       const labels = this.newLabels || this.labels
+      const defaultLabels =
+        this.flow?.run_config?.labels || this.flow?.environment?.labels
       return (
         Array.isArray(labels) &&
-        Array.isArray(this.flow?.environment?.labels) &&
-        labels.length === this.flow?.environment?.labels?.length &&
-        labels.every(
-          (val, index) => val === this.flow?.environment?.labels[index]
-        )
+        Array.isArray(defaultLabels) &&
+        labels.length === defaultLabels.length &&
+        labels.every((val, index) => val === defaultLabels[index])
       )
     }
   },
@@ -124,7 +125,11 @@ export default {
         }
         if (result.data) {
           this.newLabels =
-            newLabels || this.flowRun.labels || this.flow.environment.labels
+            newLabels ||
+            this.flowRun?.labels ||
+            this.flow?.run_config?.labels ||
+            this.flow?.environment?.labels ||
+            []
           this.resetLabelSettings()
         } else {
           this.labelsError()

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -53,10 +53,7 @@ export default {
       disableAdd: false,
       valid: false,
       errorMessage: '',
-      duplicateLabel: '',
-      rules: {
-        labelCheck: value => this.checkLabelInput(value) || this.errorMessage
-      }
+      duplicateLabel: ''
     }
   },
   computed: {
@@ -77,100 +74,12 @@ export default {
       if (!this.flow.storage || !this.flow.storage.flows) return null
       return this.flow.storage.flows
     },
-    labels() {
-      const labels =
-        this.newLabels ||
-        this.flowGroup?.labels ||
-        this.flow?.environment?.labels ||
-        []
-      return labels?.slice().sort()
-    },
-    labelResetDisabled() {
-      const labels = this.newLabels || this.labels
-      return (
-        Array.isArray(labels) &&
-        Array.isArray(this.flow?.environment?.labels) &&
-        labels.length === this.flow?.environment?.labels?.length &&
-        labels.every(
-          (val, index) => val === this.flow?.environment?.labels[index]
-        )
-      )
-    },
     hasUser() {
       return this.flow?.created_by
     }
   },
   methods: {
     ...mapActions('alert', ['setAlert']),
-    checkLabelInput(val) {
-      const labels = this.newLabels || this.labels
-      if (labels.includes(val) && !this.disableAdd) {
-        this.errorMessage = 'Duplicate label'
-        this.duplicateLabel = val
-        this.valid = false
-        return false
-      }
-      this.duplicateLabel = ''
-      this.valid = true
-      return true
-    },
-    removeLabel(labelToRemove) {
-      this.removingLabel = labelToRemove
-      this.disableRemove = true
-      const labels = this.newLabels || this.labels
-      const updatedArray = labels.filter(label => {
-        return labelToRemove != label
-      })
-      this.editLabels(updatedArray)
-    },
-    addLabel() {
-      if (!this.valid) return
-      if (!this.newLabel) return
-      this.disableAdd = true
-      const labelArray = this.newLabels || this.labels.slice()
-      labelArray.push(this.newLabel)
-      this.editLabels(labelArray)
-    },
-    async editLabels(newLabels) {
-      try {
-        const { data } = await this.$apollo.mutate({
-          mutation: require('@/graphql/Mutations/set-labels.gql'),
-          variables: {
-            flowGroupId: this.flowGroup.id,
-            labelArray: newLabels
-          }
-        })
-        if (data) {
-          this.newLabels = newLabels || this.flow.environment.labels
-          this.resetLabelSettings()
-        } else {
-          this.labelsError()
-          this.resetLabelSettings()
-        }
-      } catch (e) {
-        this.labelsError(e)
-        this.resetLabelSettings()
-      }
-    },
-    labelReset() {
-      this.editLabels(null)
-    },
-    resetLabelSettings() {
-      this.removingLabel = false
-      this.disableAdd = false
-      this.newLabel = ''
-      this.disableRemove = false
-    },
-    labelsError(e) {
-      const message = e
-        ? `There was a problem: ${e}`
-        : 'There was a problem updating your labels.  Please try again.'
-      this.setAlert({
-        alertShow: true,
-        alertMessage: message,
-        alertType: 'error'
-      })
-    },
     clickAndCopyable(field) {
       return ['image_tag', 'image_name', 'registry_url'].includes(field)
     },


### PR DESCRIPTION
If a flow has a `run_config`, the labels on the `run_config` are used,
and `flow.environment` is ignored. This updates the label logic in the
UI to take labels from the `run_config` if present.

Also deletes some dead code left in the `Details-Tile.vue` leftover from
moving label editing to the `LabelEdit` component.

PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)
