### PR TITLE
Support labels in `flow.run_config` in label warning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Features and Improvements
 
+- Check labels on `flow.run_config` when generating warning for flow labels without an agent [#312](https://github.com/PrefectHQ/ui/pull/312)
 - Use labels from `flow.run_config` if present [#309](https://github.com/PrefectHQ/ui/pull/309)
 
 ### Bugfixes
@@ -14,7 +15,6 @@
 
 ### Features and Improvements
 
-- Check labels on `flow.run_config` when generating warning for flow labels without an agent [#312](https://github.com/PrefectHQ/ui/pull/312)
 - Add section to flow details for `flow.run_config` if not null, otherwise display `flow.environment` [#307](https://github.com/PrefectHQ/ui/pull/307)
 - Enable restart from cancelled and update restart from failed [#234](https://github.com/PrefectHQ/ui/pull/234)
 - Add unit tests for the authNavGuard middleware [#266](https://github.com/PrefectHQ/ui/pull/266)

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 
 ### Features and Improvements
 
+- Check labels on `flow.run_config` when generating warning for flow labels without an agent [#312](https://github.com/PrefectHQ/ui/pull/312)
 - Add section to flow details for `flow.run_config` if not null, otherwise display `flow.environment` [#307](https://github.com/PrefectHQ/ui/pull/307)
 - Enable restart from cancelled and update restart from failed [#234](https://github.com/PrefectHQ/ui/pull/234)
 - Add unit tests for the authNavGuard middleware [#266](https://github.com/PrefectHQ/ui/pull/266)

--- a/src/components/LabelWarning.vue
+++ b/src/components/LabelWarning.vue
@@ -52,6 +52,7 @@ export default {
       return (
         this.flowRun?.labels ||
         this.flowGroup?.labels ||
+        this.flow?.run_config?.labels ||
         this.flow?.environment?.labels
       )
     },


### PR DESCRIPTION
Adds support for labels stored on a run config when generating a warning
based on flow labels without a backing agent.

Fixes #311

PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)
