### PR TITLE
Cloud Hook Prefix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Adds the project name as a prefix when creating a Cloud Hook - [#363](https://github.com/PrefectHQ/ui/pull/363)
 
 ### Bugfixes
 

--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -165,7 +165,11 @@ export default {
       return allHooks.filter(
         t => (t.requiresCloud && this.isCloud) || !t.requiresCloud
       )
-    }
+    },
+    projectNamePrefix() {
+      const prefixedName = item => item.name + " ("+item.project.name+")"
+      return prefixedName
+    },
   },
   watch: {
     loading(val) {
@@ -406,7 +410,7 @@ export default {
                   v-model="versionGroupIdSelect"
                   data-cy="flow-list"
                   item-value="version_group_id"
-                  item-text="name"
+                  :item-text="projectNamePrefix"
                   label="Flow (Version Group)"
                   class="headline overflow"
                   :items="flows"

--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -407,6 +407,7 @@ export default {
               <v-col cols="12" md="8" class="pb-0">
                 <v-autocomplete
                   v-if="canEdit && !versionGroupIdProp"
+                  id="item"
                   v-model="versionGroupIdSelect"
                   data-cy="flow-list"
                   item-value="version_group_id"
@@ -414,8 +415,14 @@ export default {
                   label="Flow (Version Group)"
                   class="headline overflow"
                   :items="flows"
-                />
-
+                >
+                  <template #item="{ item }">
+                  <v-list-item-content>
+                    <v-list-item-title>{{item.name}}</v-list-item-title>
+                    <v-list-item-subtitle>({{item.project.name}})</v-list-item-subtitle>
+                  </v-list-item-content>
+                  </template>
+                </v-autocomplete>
                 <v-text-field
                   v-if="canEdit"
                   v-model="tempName"

--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -167,9 +167,9 @@ export default {
       )
     },
     projectNamePrefix() {
-      const prefixedName = item => item.name + " ("+item.project.name+")"
+      const prefixedName = item => item.name + ' (' + item.project.name + ')'
       return prefixedName
-    },
+    }
   },
   watch: {
     loading(val) {

--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -417,10 +417,12 @@ export default {
                   :items="flows"
                 >
                   <template #item="{ item }">
-                  <v-list-item-content>
-                    <v-list-item-title>{{item.name}}</v-list-item-title>
-                    <v-list-item-subtitle>({{item.project.name}})</v-list-item-subtitle>
-                  </v-list-item-content>
+                    <v-list-item-content>
+                      <v-list-item-title>{{ item.name }}</v-list-item-title>
+                      <v-list-item-subtitle
+                        >({{ item.project.name }})</v-list-item-subtitle
+                      >
+                    </v-list-item-content>
                   </template>
                 </v-autocomplete>
                 <v-text-field

--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -165,10 +165,6 @@ export default {
       return allHooks.filter(
         t => (t.requiresCloud && this.isCloud) || !t.requiresCloud
       )
-    },
-    projectNamePrefix() {
-      const prefixedName = item => item.name + ' (' + item.project.name + ')'
-      return prefixedName
     }
   },
   watch: {
@@ -374,6 +370,9 @@ export default {
     },
     stateGroupColor(group) {
       return GROUP_COLORS[group]
+    },
+    projectNamePrefix() {
+      return item => `${item.name} (${item.project.name})`
     }
   },
   apollo: {
@@ -411,7 +410,7 @@ export default {
                   v-model="versionGroupIdSelect"
                   data-cy="flow-list"
                   item-value="version_group_id"
-                  :item-text="projectNamePrefix"
+                  :item-text="projectNamePrefix()"
                   label="Flow (Version Group)"
                   class="headline overflow"
                   :items="flows"

--- a/src/graphql/TeamSettings/flows.gql
+++ b/src/graphql/TeamSettings/flows.gql
@@ -4,5 +4,8 @@ query Flows {
     archived
     name
     version_group_id
+    project {
+      name
+    }
   }
 }

--- a/src/graphql/TeamSettings/flows.gql
+++ b/src/graphql/TeamSettings/flows.gql
@@ -5,6 +5,7 @@ query Flows {
     name
     version_group_id
     project {
+      id
       name
     }
   }


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds the project name as a prefix when creating a Cloud Hook. Before, flows with the same name under different projects (Prod, Test, Dev, etc.) were hard to identify which flow was which when creating a Cloud Hook.
