### PR TITLE
Remove flow join from the flow run history query

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Remove flow join from the flow run history query - [#365](https://github.com/PrefectHQ/ui/pull/365)
 
 ### Bugfixes
 

--- a/src/components/TimelineTooltip.vue
+++ b/src/components/TimelineTooltip.vue
@@ -6,7 +6,8 @@ export default {
     DurationSpan
   },
   props: {
-    tooltip: { type: Object, required: true }
+    tooltip: { type: Object, required: true },
+    loading: { type: Boolean, required: false, default: false }
   }
 }
 </script>
@@ -16,9 +17,12 @@ export default {
     <div v-if="props.tooltip.data.flow" class="title truncate">
       {{ props.tooltip.data.flow.name }}
     </div>
+    <div v-else-if="props.loading">
+      ...
+    </div>
     <div
       class="truncate"
-      :class="props.tooltip.data.flow ? 'caption' : 'title'"
+      :class="props.tooltip.data.flow || props.loading ? 'caption' : 'title'"
     >
       {{ props.tooltip.data.name }}
     </div>

--- a/src/graphql/Dashboard/timeline-flow-runs.gql
+++ b/src/graphql/Dashboard/timeline-flow-runs.gql
@@ -8,11 +8,8 @@ query TimelineFlowRuns($limit: Int, $project_id: uuid) {
     order_by: { scheduled_start_time: desc }
   ) {
     id
+    flow_id
     name
-    flow {
-      id
-      name
-    }
     end_time
     start_time
     scheduled_start_time

--- a/src/graphql/Dashboard/timeline-flow.gql
+++ b/src/graphql/Dashboard/timeline-flow.gql
@@ -1,0 +1,6 @@
+query TimelineFlow($flowId: uuid!) {
+  flow_by_pk(id: $flowId) {
+    id
+    name
+  }
+}

--- a/src/graphql/Dashboard/timeline-scheduled-flow-runs.gql
+++ b/src/graphql/Dashboard/timeline-scheduled-flow-runs.gql
@@ -9,10 +9,6 @@ query TimelineFlowRuns($project_id: uuid) {
   ) {
     id
     name
-    flow {
-      id
-      name
-    }
     end_time
     start_time
     scheduled_start_time

--- a/src/graphql/Dashboard/timeline-scheduled-flow-runs.gql
+++ b/src/graphql/Dashboard/timeline-scheduled-flow-runs.gql
@@ -8,6 +8,7 @@ query TimelineFlowRuns($project_id: uuid) {
     order_by: { scheduled_start_time: asc_nulls_last }
   ) {
     id
+    flow_id
     name
     end_time
     start_time

--- a/src/pages/Dashboard/Timeline-Tile.vue
+++ b/src/pages/Dashboard/Timeline-Tile.vue
@@ -88,7 +88,7 @@ export default {
       @bar-mouseover="_barMouseover"
     >
       <template v-if="canShowTooltip" slot="tooltip">
-        <TimelineTooltip :tooltip="tooltip" />
+        <TimelineTooltip :tooltip="tooltip" :loading="tooltipLoading" />
       </template>
     </BarChart>
   </v-card>


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Removes the join to the flow table for dashboard flow history queries - should improve performance of the query and pre-empt some work @jlowin is doing. 

Adds a loading state and individual queries for flow data to the bar hover handler. 