### PR TITLE
update no agents warning 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,6 @@
 ### Features and Improvements
 
 - Add ability to accept team invites on new user creation, go directly to invited team - [#322](https://github.com/PrefectHQ/ui/issues/322)
-- Add indicator of number of upcoming or late runs to the dashboard card title = [#348](https://github.com/PrefectHQ/ui/issues/348)
 - Update the agents tile on the dashboard to show flows can not run without agents [#382](https://github.com/PrefectHQ/ui/pull/382)
 - Add indicator of number of upcoming or late runs to the dashboard card title - [#348](https://github.com/PrefectHQ/ui/issues/348)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Features and Improvements
 
 - Add indicator of number of upcoming or late runs to the dashboard card title = [#348](https://github.com/PrefectHQ/ui/issues/348)
+- Update the agents tile on the dashboard to show flows can not run without agents [#382](https://github.com/PrefectHQ/ui/pull/382)
 
 ### Bugfixes
 

--- a/src/pages/Dashboard/Agents-Tile.vue
+++ b/src/pages/Dashboard/Agents-Tile.vue
@@ -4,10 +4,12 @@ import { mapGetters } from 'vuex'
 
 import CardTitle from '@/components/Card-Title'
 import moment from '@/utils/moment'
+import ExternalLink from '@/components/ExternalLink'
 
 export default {
   components: {
-    CardTitle
+    CardTitle,
+    ExternalLink
   },
   data() {
     return {
@@ -60,17 +62,14 @@ export default {
       if (this.isLoading) return 'secondaryGray'
       if (
         this.hasError ||
+        this.agents?.length === 0 ||
         (this.agentTracker?.healthy === 0 &&
           this.agentTracker?.stale === 0 &&
           this.agentTracker?.unhealthy > 0)
       )
         return 'error'
 
-      if (
-        this.agents?.length === 0 ||
-        this.agentTracker?.stale > 0 ||
-        this.agentTracker?.unhealthy > 0
-      ) {
+      if (this.agentTracker?.stale > 0 || this.agentTracker?.unhealthy > 0) {
         return 'warning'
       }
 
@@ -131,8 +130,8 @@ export default {
           color="grey"
         >
           <v-list-item-avatar class="mr-0">
-            <v-icon class="warning--text mb-1">
-              warning
+            <v-icon class="error--text mb-1">
+              error
             </v-icon>
           </v-list-item-avatar>
           <v-list-item-content class="my-0 py-3">
@@ -140,8 +139,19 @@ export default {
               class=" text-subtitle-1 font-weight-light"
               style="line-height: 1.25rem;"
             >
-              You do not have any agents querying for flow runs.
-            </div>
+              You do not have any agents querying for flow runs. Without an
+              agent, your flow runs will not be picked up.</div
+            >
+            <div
+              class=" text-subtitle-1 font-weight-light pt-4"
+              style="line-height: 1.25rem;"
+              >See
+              <ExternalLink
+                href="https://docs.prefect.io/orchestration/agents/overview.html"
+                >the Prefect docs</ExternalLink
+              >
+              for more info on agents.</div
+            >
           </v-list-item-content>
         </v-list-item>
 

--- a/src/pages/Dashboard/Agents-Tile.vue
+++ b/src/pages/Dashboard/Agents-Tile.vue
@@ -142,6 +142,16 @@ export default {
               You do not have any agents querying for flow runs. Without an
               agent, your flow runs will not be picked up.</div
             >
+            <div
+              class=" text-subtitle-1 font-weight-light pt-4"
+              style="line-height: 1.25rem;"
+              >See
+              <ExternalLink
+                href="https://docs.prefect.io/orchestration/agents/overview.html"
+                >the Prefect docs</ExternalLink
+              >
+              for more information on agents.</div
+            >
           </v-list-item-content>
         </v-list-item>
 
@@ -189,7 +199,7 @@ export default {
               not queried for flow runs in the last
               {{
                 staleThreshold === 1 ? 'minute' : `${staleThreshold} minutes`
-              }}
+              }}.
             </div>
           </v-list-item-content>
         </v-list-item>
@@ -220,14 +230,11 @@ export default {
                   unhealthyThreshold === 1
                     ? 'minute'
                     : `${unhealthyThreshold} minutes`
-                }}
+                }}.
               </span>
             </div>
-          </v-list-item-content>
-        </v-list-item>
-        <v-list-item v-if="statusColor === 'error'" key="docs-link">
-          <v-list-item-content>
             <div
+              v-if="agentTracker && agentTracker.healthy < 1"
               class=" text-subtitle-1 font-weight-light pt-4"
               style="line-height: 1.25rem;"
               >See

--- a/src/pages/Dashboard/Agents-Tile.vue
+++ b/src/pages/Dashboard/Agents-Tile.vue
@@ -142,16 +142,6 @@ export default {
               You do not have any agents querying for flow runs. Without an
               agent, your flow runs will not be picked up.</div
             >
-            <div
-              class=" text-subtitle-1 font-weight-light pt-4"
-              style="line-height: 1.25rem;"
-              >See
-              <ExternalLink
-                href="https://docs.prefect.io/orchestration/agents/overview.html"
-                >the Prefect docs</ExternalLink
-              >
-              for more info on agents.</div
-            >
           </v-list-item-content>
         </v-list-item>
 
@@ -233,6 +223,20 @@ export default {
                 }}
               </span>
             </div>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item v-if="statusColor === 'error'" key="docs-link">
+          <v-list-item-content>
+            <div
+              class=" text-subtitle-1 font-weight-light pt-4"
+              style="line-height: 1.25rem;"
+              >See
+              <ExternalLink
+                href="https://docs.prefect.io/orchestration/agents/overview.html"
+                >the Prefect docs</ExternalLink
+              >
+              for more information on agents.</div
+            >
           </v-list-item-content>
         </v-list-item>
       </v-slide-y-reverse-transition>


### PR DESCRIPTION


PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- Changes the no agents tile color from 'warning' orange to 'error' red and updates the messages to say flows will not run without agents.  
- Also adds a link to the agents docs. 
- Together with the work on flow affinity labels, I think this closes #215 