### PR TITLE
Refetch task run states after flow run finishes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix a bug on restart from failed which was missing failed task runs [#398](https://github.com/PrefectHQ/ui/pull/398)
 
 ## 2020-10-29a
 

--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -59,6 +59,9 @@ export default {
       if (oldVal.state === 'Scheduled' && newVal.state !== 'Scheduled') {
         this.isRunningNow = false
       }
+      if (FINISHED_STATES.includes(newVal.state)) {
+        this.$apollo.queries.failedTaskRuns.refetch()
+      }
     }
   },
   methods: {
@@ -66,7 +69,6 @@ export default {
     deleteFlowRun() {},
     handleRestartClick() {
       this.restartDialog = true
-      this.$apollo.queries.failedTaskRuns.refetch()
     },
     async runFlowNow() {
       this.runFlowNowLoading = true

--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -59,7 +59,10 @@ export default {
       if (oldVal.state === 'Scheduled' && newVal.state !== 'Scheduled') {
         this.isRunningNow = false
       }
-     if (newVal.state !== oldVal.state && FINISHED_STATES.includes(newVal.state)) {
+      if (
+        newVal.state !== oldVal.state &&
+        FINISHED_STATES.includes(newVal.state)
+      ) {
         this.$apollo.queries.failedTaskRuns.refetch()
       }
     }

--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -39,7 +39,6 @@ export default {
   computed: {
     ...mapGetters('tenant', ['tenant', 'role']),
     isReadOnlyUser() {
-      console.log(1, this.failedTaskRuns)
       return this.role === 'READ_ONLY_USER'
     },
     isScheduled() {

--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -59,7 +59,7 @@ export default {
       if (oldVal.state === 'Scheduled' && newVal.state !== 'Scheduled') {
         this.isRunningNow = false
       }
-      if (FINISHED_STATES.includes(newVal.state)) {
+     if (newVal.state !== oldVal.state && FINISHED_STATES.includes(newVal.state)) {
         this.$apollo.queries.failedTaskRuns.refetch()
       }
     }

--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -39,6 +39,7 @@ export default {
   computed: {
     ...mapGetters('tenant', ['tenant', 'role']),
     isReadOnlyUser() {
+      console.log(1, this.failedTaskRuns)
       return this.role === 'READ_ONLY_USER'
     },
     isScheduled() {
@@ -64,6 +65,10 @@ export default {
   methods: {
     ...mapActions('alert', ['setAlert']),
     deleteFlowRun() {},
+    handleRestartClick() {
+      this.restartDialog = true
+      this.$apollo.queries.failedTaskRuns.refetch()
+    },
     async runFlowNow() {
       this.runFlowNowLoading = true
 
@@ -163,7 +168,7 @@ export default {
             small
             :disabled="isReadOnlyUser || !canRestart"
             color="info"
-            @click="restartDialog = true"
+            @click="handleRestartClick"
           >
             <v-icon>fab fa-rev</v-icon>
             <div>Restart</div>

--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -68,6 +68,7 @@ export default {
     ...mapActions('alert', ['setAlert']),
     deleteFlowRun() {},
     handleRestartClick() {
+      this.$apollo.queries.failedTaskRuns.refetch()
       this.restartDialog = true
     },
     async runFlowNow() {

--- a/src/pages/FlowRun/Restart-Dialog.vue
+++ b/src/pages/FlowRun/Restart-Dialog.vue
@@ -28,7 +28,6 @@ export default {
       return `${this.user.username} restarted this flow run`
     },
     isEligibleToRestart() {
-      console.log(this.failedTaskRuns)
       return (
         this.hasFailedTaskRuns ||
         this.eligibleStates.includes(this.flowRun.state)

--- a/src/pages/FlowRun/Restart-Dialog.vue
+++ b/src/pages/FlowRun/Restart-Dialog.vue
@@ -28,6 +28,7 @@ export default {
       return `${this.user.username} restarted this flow run`
     },
     isEligibleToRestart() {
+      console.log(this.failedTaskRuns)
       return (
         this.hasFailedTaskRuns ||
         this.eligibleStates.includes(this.flowRun.state)


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
- Closes #369 and fixes a bug on restart from failed which was missing failed task runs
- Refetches the failed task run query after a flow run finishes (previously this was not catching failed task runs if the flow run page was not refreshed after running)