### PR TITLE
Scrollbar bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix issue where scrollbars show on all tiles even when not needed - [#366](https://github.com/PrefectHQ/ui/issues/366)
 
 ## 2020-10-29a
 

--- a/src/components/Agents/AgentCard.vue
+++ b/src/components/Agents/AgentCard.vue
@@ -183,8 +183,9 @@ export default {
   <v-card
     tile
     :disabled="isDeleting"
-    class="agent-card overflow-y-scroll px-2 pb-3"
+    class="agent-card px-2 pb-3"
     :min-height="$vuetify.breakpoint.smAndDown ? null : 260"
+    style="overflow-y: auto;"
   >
     <v-system-bar :color="statusColor" :height="5" absolute> </v-system-bar>
 
@@ -356,7 +357,7 @@ export default {
       </div>
       <div
         v-if="agent && agentModified.labels.length > 0"
-        class="px-3 overflow-y-scroll"
+        class="px-3"
         style="height: 80px;"
       >
         <v-chip-group column multiple style="user-select: none;">

--- a/src/components/LabelEdit.vue
+++ b/src/components/LabelEdit.vue
@@ -164,8 +164,8 @@ export default {
 </script>
 
 <template>
-  <v-list-item dense class="px-0">
-    <v-list-item-content width="800px" class="overflow-x-scroll">
+  <v-list-item dense>
+    <v-list-item-content width="800px" style="overflow-x: auto;">
       <v-list-item-subtitle class="caption">
         Labels
         <v-menu :close-on-content-click="false" offset-y open-on-hover>
@@ -230,7 +230,7 @@ export default {
                 <span v-else>Add a label</span>
               </v-tooltip>
             </template>
-            <v-card width="800px" class="overflow-y-scroll py-0">
+            <v-card width="800px" class="py-0">
               <v-card-title class="subtitle pr-2 pt-2 pb-0"
                 >{{ flowOrFlowRun }} labels</v-card-title
               >
@@ -352,7 +352,7 @@ export default {
             <span v-else>Add a label</span>
           </v-tooltip>
         </template>
-        <v-card width="800px" class="overflow-y-scroll py-0">
+        <v-card width="800px" class="py-0">
           <v-card-title class="subtitle pr-2 pt-2 pb-0"
             >{{ flowOrFlowRun }} labels</v-card-title
           >

--- a/src/components/LogsCard/LogsCard.vue
+++ b/src/components/LogsCard/LogsCard.vue
@@ -741,7 +741,6 @@ export default {
 
 .logs-card {
   background-color: transparent;
-  overflow: scroll;
   position: relative;
 }
 
@@ -759,7 +758,7 @@ export default {
 
 .logs-list {
   max-height: 62vh;
-  overflow-y: scroll;
+  overflow: auto;
   position: relative;
 }
 

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -926,7 +926,7 @@ export default {
   bottom: 0;
   left: 300px;
   max-height: calc(100% - 100px);
-  overflow-y: scroll;
+  overflow-y: auto;
   position: absolute;
   width: 100%;
 

--- a/src/pages/Dashboard/Agents-Tile.vue
+++ b/src/pages/Dashboard/Agents-Tile.vue
@@ -267,7 +267,7 @@ export default {
 .card-content {
   height: 100%;
   max-height: 210px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .time-interval-picker {

--- a/src/pages/Dashboard/FailedFlows-Tile.vue
+++ b/src/pages/Dashboard/FailedFlows-Tile.vue
@@ -138,8 +138,8 @@ export default {
       </span>
     </v-tooltip>
 
-    <v-card-text class="card-content pa-0">
-      <v-list>
+    <v-card-text class="pa-0">
+      <v-list class="card-content">
         <v-slide-y-reverse-transition v-if="loading > 0" leave-absolute group>
           <v-skeleton-loader key="skeleton" type="list-item-three-line">
           </v-skeleton-loader>
@@ -233,7 +233,7 @@ export default {
 .card-content {
   height: 100%;
   max-height: 254px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .footer {

--- a/src/pages/Dashboard/InProgress-Tile.vue
+++ b/src/pages/Dashboard/InProgress-Tile.vue
@@ -215,11 +215,11 @@ export default {
       </div>
     </CardTitle>
 
-    <v-card-text class="pa-0 card-content">
+    <v-card-text class="pa-0">
       <v-skeleton-loader v-if="loading" type="list-item-three-line">
       </v-skeleton-loader>
 
-      <v-list v-else-if="!loading && runs.length === 0">
+      <v-list v-else-if="!loading && runs.length === 0" class="card-content">
         <v-list-item>
           <v-list-item-avatar class="mr-0">
             <v-icon class="mb-1" :color="tileColor">
@@ -245,7 +245,7 @@ export default {
         </v-list-item>
       </v-list>
 
-      <v-list v-else>
+      <v-list v-else class="card-content">
         <v-slide-x-transition mode="out-in" leave-absolute group>
           <v-lazy
             v-for="run in runs"
@@ -329,7 +329,7 @@ a {
 
 .card-content {
   max-height: 254px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .card-footer {

--- a/src/pages/Dashboard/Notifications-Tile.vue
+++ b/src/pages/Dashboard/Notifications-Tile.vue
@@ -137,11 +137,11 @@ export default {
       :loading="isLoading"
     />
 
-    <v-card-text class="pa-0 card-content">
+    <v-card-text class="pa-0">
       <v-skeleton-loader v-if="isLoading" type="list-item-three-line">
       </v-skeleton-loader>
 
-      <v-list v-else-if="notificationsCount > 0">
+      <v-list v-else-if="notificationsCount > 0" class=" card-content">
         <template v-for="(n, i) in notifications">
           <v-list-item
             :key="n.id"
@@ -204,6 +204,6 @@ export default {
 .card-content {
   height: 100%;
   max-height: 210px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 </style>

--- a/src/pages/Dashboard/Summary-Tile.vue
+++ b/src/pages/Dashboard/Summary-Tile.vue
@@ -299,7 +299,6 @@ export default {
 <style lang="scss">
 .card-content {
   height: 254px;
-  overflow-y: scroll;
 }
 
 .centered-skeleton {

--- a/src/pages/Dashboard/UpcomingRuns-Tile.vue
+++ b/src/pages/Dashboard/UpcomingRuns-Tile.vue
@@ -239,7 +239,7 @@ export default {
       </div>
     </CardTitle>
 
-    <v-card-text v-if="tab == 'upcoming'" class="pa-0 card-content">
+    <v-card-text v-if="tab == 'upcoming'" class="pa-0">
       <v-skeleton-loader v-if="loading > 0" type="list-item-three-line">
       </v-skeleton-loader>
 
@@ -260,7 +260,7 @@ export default {
         </v-list-item-content>
       </v-list-item>
 
-      <v-list v-else dense>
+      <v-list v-else dense class="card-content">
         <v-lazy
           v-for="item in upcomingRuns"
           :key="item.id"
@@ -352,7 +352,7 @@ export default {
         </v-list-item-content>
       </v-list-item>
 
-      <v-list v-else dense>
+      <v-list v-else dense class="card-content">
         <v-lazy
           v-for="item in lateRuns"
           :key="item.id"
@@ -476,7 +476,7 @@ a {
 
 .card-content {
   max-height: 254px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .card-footer {

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -172,10 +172,10 @@ export default {
       </div>
     </CardTitle>
 
-    <v-card-text class="pl-12 pt-2 card-content">
+    <v-card-text class="pa-0">
       <v-fade-transition hide-on-leave>
-        <div v-if="tab == 'overview'">
-          <v-list-item dense class="px-0">
+        <v-list v-if="tab == 'overview'" class="card-content">
+          <v-list-item dense>
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Created <span v-if="hasUser">by</span>
@@ -189,7 +189,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item v-if="flow.core_version" dense class="px-0">
+          <v-list-item v-if="flow.core_version" dense>
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Prefect Core Version:
@@ -198,7 +198,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item dense class="px-0">
+          <v-list-item dense>
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Schedule
@@ -214,12 +214,12 @@ export default {
           </v-list-item>
 
           <LabelEdit :flow="flow" :flow-group="flowGroup" />
-        </div>
+        </v-list>
       </v-fade-transition>
 
       <v-fade-transition hide-on-leave>
-        <div v-if="tab == 'details'">
-          <v-list-item dense class="px-0">
+        <v-list v-if="tab == 'details'" class="card-content">
+          <v-list-item dense>
             <v-list-item-content>
               <v-list-item-subtitle class="grey--text text--darken-3">
                 General
@@ -326,7 +326,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item dense class="px-0">
+          <v-list-item dense>
             <v-list-item-content v-if="flow.run_config">
               <v-list-item-subtitle class="grey--text text--darken-3">
                 Run Config
@@ -370,7 +370,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item v-if="flow.storage" dense class="px-0 mt-2">
+          <v-list-item v-if="flow.storage" dense class="mt-2">
             <v-list-item-content>
               <v-list-item-subtitle class="grey--text text--darken-3">
                 Storage
@@ -424,7 +424,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item v-if="flows" dense class="px-0 mt-2">
+          <v-list-item v-if="flows" dense class="mt-2">
             <v-list-item-content>
               <v-list-item-subtitle class="grey--text text--darken-3">
                 Flow Locations
@@ -452,7 +452,6 @@ export default {
             v-if="flow.parameters && flow.parameters.length > 0"
             dense
             two-line
-            class="px-0"
           >
             <v-list-item-content>
               <v-list-item-subtitle class="grey--text text--darken-3">
@@ -517,7 +516,7 @@ export default {
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-list-item>
-        </div>
+        </v-list>
       </v-fade-transition>
     </v-card-text>
   </v-card>
@@ -536,7 +535,7 @@ export default {
 
 .card-content {
   max-height: 254px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .cursor-pointer {

--- a/src/pages/Flow/Errors-Tile.vue
+++ b/src/pages/Flow/Errors-Tile.vue
@@ -276,7 +276,7 @@ export default {
 <style lang="scss" scoped>
 .error-card-content {
   max-height: 254px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .error-footer {

--- a/src/pages/Flow/Summary-Tile.vue
+++ b/src/pages/Flow/Summary-Tile.vue
@@ -317,7 +317,6 @@ export default {
 <style lang="scss">
 .card-content {
   height: 254px;
-  overflow-y: scroll;
 }
 
 .centered-skeleton {

--- a/src/pages/Flow/UpcomingRuns-Tile.vue
+++ b/src/pages/Flow/UpcomingRuns-Tile.vue
@@ -283,7 +283,7 @@ export default {
       </div>
     </CardTitle>
 
-    <v-card-text v-if="tab == 'upcoming'" class="pa-0 card-content">
+    <v-card-text v-if="tab == 'upcoming'" class="pa-0">
       <v-skeleton-loader v-if="loading > 0" type="list-item-three-line">
       </v-skeleton-loader>
 
@@ -310,7 +310,7 @@ export default {
         </v-list-item-content>
       </v-list-item>
 
-      <v-list v-else dense>
+      <v-list v-else dense class="card-content">
         <v-lazy
           v-for="item in upcomingRuns"
           :key="item.id"
@@ -407,7 +407,7 @@ export default {
         </v-list-item-content>
       </v-list-item>
 
-      <v-list v-else dense>
+      <v-list v-else dense class="card-content">
         <v-lazy
           v-for="item in lateRuns"
           :key="item.id"
@@ -511,7 +511,6 @@ a {
 
 .card-content {
   max-height: 254px;
-  overflow-y: scroll;
 }
 
 .card-footer {

--- a/src/pages/FlowRun/Details-Tile.vue
+++ b/src/pages/FlowRun/Details-Tile.vue
@@ -144,10 +144,10 @@ export default {
 
     <CardTitle v-else :title="flowRun.name" icon="pi-flow-run" />
 
-    <v-card-text class="pl-12 card-content">
+    <v-card-text class="pa-0">
       <v-fade-transition hide-on-leave>
-        <div v-if="tab === 'overview'">
-          <v-list-item v-if="isCloudOrAutoScheduled" class="px-0">
+        <v-list v-if="tab === 'overview'">
+          <v-list-item v-if="isCloudOrAutoScheduled">
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Created by
@@ -164,7 +164,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item v-if="flowRun.state_message" dense class="px-0">
+          <v-list-item v-if="flowRun.state_message" dense>
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Last State Message
@@ -185,7 +185,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item v-if="flowRun.agent_id" dense class="px-0">
+          <v-list-item v-if="flowRun.agent_id" dense>
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 Agent ID
@@ -203,7 +203,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
 
-          <v-list-item dense class="pa-0">
+          <v-list-item dense>
             <v-list-item-content>
               <v-list-item-subtitle class="caption">
                 <v-row no-gutters>
@@ -291,7 +291,7 @@ export default {
             </v-list-item-content>
           </v-list-item>
           <LabelEdit type="flowRun" :flow-run="flowRun" />
-        </div>
+        </v-list>
       </v-fade-transition>
 
       <v-fade-transition hide-on-leave>
@@ -318,7 +318,7 @@ export default {
 <style lang="scss" scoped>
 .card-content {
   max-height: 254px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .code-block {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -233,10 +233,6 @@ body {
   overflow-y: hidden !important;
 }
 
-.overflow-y-scroll {
-  overflow-y: scroll !important;
-}
-
 .overflow-x-scroll {
   overflow-x: scroll !important;
 }


### PR DESCRIPTION
PR Checklist:

- [X] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
User reported, and I also saw, unnecessary scrollbars showing up on many/most tiles on the assorted dashboards, even when there was not information overflowing the container. Strangely, @zhen0 wasn't seeing this on her computer, even with the same version of Chrome? Changed `overflow-y: scroll` to `overflow-y: auto` in many places to fix this, and removed the (now unused) `overflow-y-scroll` global class.

Note: I also made some changes to the overall layout of the Details tile, as it was using a `div` instead of the `v-list` the other tiles were using and causing different paddings.