### PR TITLE
Add more info to flow Run Config details section

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Features and Improvements
 
 - Add indicator for resource manager tasks - [#396](https://github.com/PrefectHQ/ui/pull/396)
+- Add more info to a flow's "Run Config" details section - [#400](https://github.com/PrefectHQ/ui/pull/400)
 
 ### Bugfixes
 

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -70,6 +70,28 @@ export default {
           return obj
         }, {})
     },
+    runConfigDisplayFields() {
+      if (!this.flow.run_config || !this.flow.run_config.type) return []
+
+      let fields = ['type']
+      if (this.flow.run_config.type == 'LocalRun') {
+        fields.push('working_dir')
+      } else if (this.flow.run_config.type == 'DockerRun') {
+        fields.push('image')
+      } else if (this.flow.run_config.type == 'KubernetesRun') {
+        fields.push(
+          'image',
+          'job_template_path',
+          'cpu_request',
+          'cpu_limit',
+          'memory_request',
+          'memory_limit'
+        )
+      } else if (this.flow.run_config.type == 'ECSRun') {
+        fields.push('image', 'task_definition_path', 'cpu', 'memory')
+      }
+      return fields.filter(field => this.flow.run_config[field] != null)
+    },
     flows() {
       if (!this.flow.storage || !this.flow.storage.flows) return null
       return this.flow.storage.flows
@@ -333,12 +355,19 @@ export default {
               </v-list-item-subtitle>
               <v-divider style="max-width: 50%;" />
               <v-list-item-subtitle class="caption">
-                <v-row v-if="flow.run_config.type" no-gutters>
+                <v-row
+                  v-for="field in runConfigDisplayFields"
+                  :key="field"
+                  no-gutters
+                >
                   <v-col cols="6">
-                    Type
+                    {{ field }}
                   </v-col>
-                  <v-col cols="6" class="text-right font-weight-bold">
-                    {{ flow.run_config.type }}
+                  <v-col
+                    cols="6"
+                    class="text-right font-weight-bold text-truncate"
+                  >
+                    {{ flow.run_config[field] }}
                   </v-col>
                 </v-row>
               </v-list-item-subtitle>


### PR DESCRIPTION
Previously we only displayed the `type`, we now display a select subset of the fields for each (known) type of `RunConfig`. Only non-null fields are displayed, and none of the values should be terribly large, so for most users things should display nicely.

PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
