### PR TITLE
Fix issue with notifications tile actions not being aligned to bottom

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Fix a bug on restart from failed which was missing failed task runs [#398](https://github.com/PrefectHQ/ui/pull/398)
 - Fix issue where scrollbars show on all tiles even when not needed - [#366](https://github.com/PrefectHQ/ui/issues/366)
 - Include flow parameters in parameters shown in the flow run parameters tab - [#401](https://github.com/PrefectHQ/ui/pull/401)
+- Fix issue with notifications tile actions not being aligned to bottom #410 - [#410](https://github.com/PrefectHQ/ui/pull/410)
 
 ## 2020-10-29a
 

--- a/src/pages/Dashboard/Notifications-Tile.vue
+++ b/src/pages/Dashboard/Notifications-Tile.vue
@@ -137,7 +137,7 @@ export default {
       :loading="isLoading"
     />
 
-    <v-card-text class="pa-0">
+    <v-card-text class="pa-0 card-content">
       <v-skeleton-loader v-if="isLoading" type="list-item-three-line">
       </v-skeleton-loader>
 


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes an issue where the notifications tile actions weren't aligned to the bottom of the card (as other tile actions are):
![Screen Shot 2020-11-09 at 5 05 09 PM](https://user-images.githubusercontent.com/27291717/98602038-d600df00-22ad-11eb-9ae1-a036963f100c.png)
![Screen Shot 2020-11-09 at 5 04 25 PM](https://user-images.githubusercontent.com/27291717/98602045-d7320c00-22ad-11eb-8ef7-0d10dbd4ec56.png)
