### PR TITLE
Cut changelog ahead of 2020-11-11 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,16 @@
 
 ### Features and Improvements
 
+- None
+
+### Bugfixes
+
+- None
+
+## 2020-11-11
+
+### Features and Improvements
+
 - Add a "Your Teams" page to the User menu, allowing you to see and change memberships - [#194](https://github.com/PrefectHQ/ui/issues/194)
 - Allow querying for agents from the IAPI - [#425](https://github.com/PrefectHQ/ui/pull/425)
 - Add a "Clean Up" button to allow bulk removal of unhealthy agents - [#425](https://github.com/PrefectHQ/ui/pull/425)
@@ -12,6 +22,7 @@
 ### Bugfixes
 
 - Fix an issue where agent labels were overflowing their bounding box - [#425](https://github.com/PrefectHQ/ui/pull/425)
+- Make sure task runs are fetched for the set state button - [#411](https://github.com/PrefectHQ/ui/pull/411)
 
 ## 2020-11-10
 
@@ -29,7 +40,6 @@
 - Fix a bug on restart from failed which was missing failed task runs [#398](https://github.com/PrefectHQ/ui/pull/398)
 - Fix issue where scrollbars show on all tiles even when not needed - [#366](https://github.com/PrefectHQ/ui/issues/366)
 - Include flow parameters in parameters shown in the flow run parameters tab - [#401](https://github.com/PrefectHQ/ui/pull/401)
-- Make sure task runs are fetched for the set state button - [#411](https://github.com/PrefectHQ/ui/pull/411)
 - Fix issue with notifications tile actions not being aligned to bottom - [#410](https://github.com/PrefectHQ/ui/pull/410)
 
 ## 2020-10-29a


### PR DESCRIPTION
## 2020-11-11

### Features and Improvements

- Add a "Your Teams" page to the User menu, allowing you to see and change memberships - [#194](https://github.com/PrefectHQ/ui/issues/194)
- Allow querying for agents from the IAPI - [#425](https://github.com/PrefectHQ/ui/pull/425)
- Add a "Clean Up" button to allow bulk removal of unhealthy agents - [#425](https://github.com/PrefectHQ/ui/pull/425)
- Remove obsolete invitation sort code in for pending invitation queries - [#417](https://github.com/PrefectHQ/ui/pull/417)

### Bugfixes

- Fix an issue where agent labels were overflowing their bounding box - [#425](https://github.com/PrefectHQ/ui/pull/425)
- Make sure task runs are fetched for the set state button - [#411](https://github.com/PrefectHQ/ui/pull/411)
