### PR TITLE
Display the core version in the sidebar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Add the Prefect Core version to the side navigation bar for Server users - [#431](https://github.com/PrefectHQ/ui/pull/431)
 
 ### Bugfixes
 

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -64,7 +64,8 @@ export default {
       'isServer',
       'isCloud',
       'version',
-      'releaseTimestamp'
+      'releaseTimestamp',
+      'coreVersion'
     ]),
     ...mapGetters('sideNav', ['isOpen']),
     ...mapGetters('tenant', ['tenant', 'tenants', 'tenantIsSet']),
@@ -339,6 +340,10 @@ export default {
               </v-btn>
             </v-list-item-action>
           </v-list-item>
+
+          <v-list-item-content>
+            Version: {{ coreVersion }}
+          </v-list-item-content>
 
           <v-list-item
             active-class="primary-active-class"

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -341,10 +341,6 @@ export default {
             </v-list-item-action>
           </v-list-item>
 
-          <v-list-item-content>
-            Version: {{ coreVersion }}
-          </v-list-item-content>
-
           <v-list-item
             active-class="primary-active-class"
             data-cy="side-nav-dashboard-item"
@@ -592,6 +588,15 @@ export default {
               </v-list-item-title>
             </v-list-item-content>
           </v-list-item>
+
+          <div v-if="coreVersion && isServer" class="pb-2 overline text-center">
+            <div class="grey--text">
+              Core Version
+            </div>
+            <div class="font-weight-medium" style="line-height: 1;">
+              {{ coreVersion }}
+            </div>
+          </div>
 
           <v-list-item
             v-if="isCloud"

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -324,31 +324,26 @@ export default {
       <div class="lists-wrapper" @click="tenantMenuOpen = false">
         <v-list flat>
           <v-list-item class="side-nav-header">
-            <v-list flat>
-              <v-list-item>
-                <v-list-item-content>
-                  <v-img
-                    height="40"
-                    contain
-                    class="logo"
-                    position="left"
-                    :src="navLogo"
-                    alt="Prefect Logo"
-                  />
-                </v-list-item-content>
-                <v-list-item-action>
-                  <v-btn icon small @click="close">
-                    <v-icon>close</v-icon>
-                  </v-btn>
-                </v-list-item-action>
-              </v-list-item>
-              <v-list-item v-if="coreVersion">
-                <v-list-item-content>
-                  Version: {{ coreVersion }}
-                </v-list-item-content>
-              </v-list-item>
-            </v-list>
+            <v-list-item-content>
+              <v-img
+                height="40"
+                contain
+                class="logo"
+                position="left"
+                :src="navLogo"
+                alt="Prefect Logo"
+              />
+            </v-list-item-content>
+            <v-list-item-action>
+              <v-btn icon small @click="close">
+                <v-icon>close</v-icon>
+              </v-btn>
+            </v-list-item-action>
           </v-list-item>
+
+          <v-list-item-content>
+            Version: {{ coreVersion }}
+          </v-list-item-content>
 
           <v-list-item
             active-class="primary-active-class"

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -324,26 +324,31 @@ export default {
       <div class="lists-wrapper" @click="tenantMenuOpen = false">
         <v-list flat>
           <v-list-item class="side-nav-header">
-            <v-list-item-content>
-              <v-img
-                height="40"
-                contain
-                class="logo"
-                position="left"
-                :src="navLogo"
-                alt="Prefect Logo"
-              />
-            </v-list-item-content>
-            <v-list-item-action>
-              <v-btn icon small @click="close">
-                <v-icon>close</v-icon>
-              </v-btn>
-            </v-list-item-action>
+            <v-list flat>
+              <v-list-item>
+                <v-list-item-content>
+                  <v-img
+                    height="40"
+                    contain
+                    class="logo"
+                    position="left"
+                    :src="navLogo"
+                    alt="Prefect Logo"
+                  />
+                </v-list-item-content>
+                <v-list-item-action>
+                  <v-btn icon small @click="close">
+                    <v-icon>close</v-icon>
+                  </v-btn>
+                </v-list-item-action>
+              </v-list-item>
+              <v-list-item v-if="coreVersion">
+                <v-list-item-content>
+                  Version: {{ coreVersion }}
+                </v-list-item-content>
+              </v-list-item>
+            </v-list>
           </v-list-item>
-
-          <v-list-item-content>
-            Version: {{ coreVersion }}
-          </v-list-item-content>
 
           <v-list-item
             active-class="primary-active-class"

--- a/src/graphql/api.gql
+++ b/src/graphql/api.gql
@@ -3,6 +3,7 @@ query Api {
     backend
     mode
     version
+    core_version
     release_timestamp
   }
 }

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -16,7 +16,7 @@ const state = {
   cloudUrl: process.env.VUE_APP_CLOUD_URL,
   retries: 0,
   serverUrl: localStorage.getItem(SERVER_KEY),
-  version: null
+  version: null,
   core_version: null
 }
 

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -69,6 +69,9 @@ const getters = {
   },
   version(state) {
     return state.version
+  },
+  coreVersion(state) {
+    return state.coreVersion
   }
 }
 
@@ -133,10 +136,10 @@ const mutations = {
     state.version = null
   },
   setCoreVersion(state, version) {
-    state.core_version = version
+    state.coreVersion = version
   },
   unsetCoreVersion(state) {
-    state.core_version = null
+    state.coreVersion = null
   }
 }
 

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -17,6 +17,7 @@ const state = {
   retries: 0,
   serverUrl: localStorage.getItem(SERVER_KEY),
   version: null
+  core_version: null
 }
 
 const getters = {
@@ -130,6 +131,12 @@ const mutations = {
   },
   unsetVersion(state) {
     state.version = null
+  },
+  setCoreVersion(state, version) {
+    state.core_version = version
+  },
+  unsetCoreVersion(state) {
+    state.core_version = null
   }
 }
 
@@ -142,11 +149,13 @@ const actions = {
       })
       commit('setReleaseTimestamp', data.api.release_timestamp)
       commit('setVersion', data.api.version)
+      commit('setCoreVersion', data.api.core_version)
       commit('setConnected', true)
       commit('setApiMode', data.api.mode)
     } catch (error) {
       commit('unsetReleaseTimetamp')
       commit('unsetVersion')
+      commit('unsetCoreVersion')
       commit('setConnected', false)
 
       LogRocket.captureException(error, {


### PR DESCRIPTION
☁️ This feature cannot be merged until `core_version` is in prod. [See tracking](https://github.com/PrefectHQ/cloud/projects/2#card-49257453)

PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR

Adds the core version from https://github.com/PrefectHQ/server/pull/126 to the state and displays it in the sidebar under the Prefect logo

<img width="308" alt="Screen Shot 2020-11-12 at 1 40 30 PM" src="https://user-images.githubusercontent.com/2586601/98988248-38d7bd80-24dc-11eb-91ab-89afbf64139c.png">


Notes:
- The core version will only display for Server because it is not meaningful from Cloud
- For sanctioned versions, the +... commits ahead of master cruft should not be there but a release of Server needs to be cut for me to show it a screenshot