### PR TITLE
Editable flow run names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Allow editing flow run names from the flow run page - [#448](https://github.com/PrefectHQ/ui/pull/448)
 
 ### Bugfixes
 

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -62,13 +62,25 @@ export default {
     class="inherited-text-field"
     :class="{ focused: focused, 'cursor-pointer': !focused }"
   >
-    <v-icon small class="edit-icon">edit</v-icon>
+    <v-icon v-if="!loading" small class="prepend-input edit-icon">edit</v-icon>
+    <v-progress-circular
+      v-else
+      indeterminate
+      class="prepend-input"
+      color="primary"
+      size="16"
+      width="2"
+    />
 
-    <div
+    <v-input
       class="input-container"
       :class="{
-        'error-border': required && (!value || value.length === 0)
+        'error-border': required && (!value || value.length === 0),
+        disabled: !loading
       }"
+      hide-details
+      :error="required && (!value || value.length === 0)"
+      @disabled="loading"
     >
       <input
         ref="edit-input"
@@ -78,12 +90,11 @@ export default {
           'cursor-pointer': !focused
         }"
         min="1"
-        @disabled="loading"
-        @focus="focused = true"
         @keyup.enter="save"
         @keyup.esc="discard"
+        @focus="focused = true"
       />
-    </div>
+    </v-input>
 
     <!-- Not sure if we need to show these buttons since enter is a pretty natural interaction -->
     <!-- <div v-if="focused" class="button-container text-center">
@@ -113,11 +124,14 @@ export default {
   width: 60px;
 }
 
-.edit-icon {
+.prepend-input {
   left: -20px;
-  opacity: 0;
   position: absolute;
   top: 6px;
+}
+
+.edit-icon {
+  opacity: 0;
   transition: all 150ms;
 }
 
@@ -131,13 +145,24 @@ export default {
   position: relative;
   width: 100%;
 
-  input,
-  input:active {
-    outline: none;
-    width: 100%;
+  .v-input {
+    color: inherit !important;
+    font-size: inherit !important;
+  }
+
+  &.disabled {
+    .v-input {
+      color: #d00 !important;
+    }
   }
 
   .input-container {
+    input,
+    input:active {
+      outline: none;
+      width: 100%;
+    }
+
     &::after {
       background-color: #3b8dff;
       bottom: 0;

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -27,6 +27,7 @@ export default {
   methods: {
     discard() {
       this.isEditing = false
+      this.$refs['edit-input']?.blur()
 
       this.value = this.content
     },
@@ -37,6 +38,7 @@ export default {
     },
     save() {
       this.isEditing = false
+      this.$refs['edit-input']?.blur()
 
       this.$emit('change', this.value)
     }
@@ -84,12 +86,12 @@ export default {
   max-width: 100%;
   padding-bottom: 2px;
   position: relative;
-  width: fit-content;
+  width: 100%;
 
   input,
   input:active {
     outline: none;
-    width: auto;
+    width: 100%;
   }
 
   .input-container::after {

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -61,6 +61,7 @@ export default {
         @disabled="!isEditing"
         @focus="focused = true"
         @blur="focused = false"
+        @keyup.enter="save"
       />
     </div>
   </div>

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -26,18 +26,18 @@ export default {
   },
   methods: {
     discard() {
-      this.isEditing = false
+      this.focused = false
       this.$refs['edit-input']?.blur()
 
       this.value = this.content
     },
     edit() {
-      this.isEditing = true
+      this.focused = true
       console.log(this.$refs)
       this.$refs['edit-input']?.focus()
     },
     save() {
-      this.isEditing = false
+      this.focused = false
       this.$refs['edit-input']?.blur()
 
       this.$emit('change', this.value)
@@ -62,20 +62,23 @@ export default {
         :class="{ 'cursor-pointer': !focused }"
         @disabled="!isEditing"
         @focus="focused = true"
-        @blur="focused = false"
         @keyup.enter="save"
       />
+    </div>
+
+    <div v-if="focused" class="button-container">
+      <v-btn depressed x-small class="mr-1" @click="discard">Cancel</v-btn>
+      <v-btn depressed color="primary" x-small @click="save">Save</v-btn>
     </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.edit-icon {
-  float: right;
-}
-
-.original-border {
-  border: 1px solid #ddd;
+.button-container {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translate(0, -50%);
 }
 
 .inherited-text-field {

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -41,7 +41,7 @@ export default {
     },
     edit() {
       this.focused = true
-      console.log(this.$refs)
+
       this.$refs['edit-input']?.focus()
     },
     save() {
@@ -61,6 +61,7 @@ export default {
     v-click-outside="discard"
     class="inherited-text-field"
     :class="{ focused: focused, 'cursor-pointer': !focused }"
+    @click="edit"
   >
     <v-icon v-if="!loading" small class="prepend-input edit-icon">edit</v-icon>
     <v-progress-circular
@@ -76,7 +77,7 @@ export default {
       class="input-container"
       :class="{
         'error-border': required && (!value || value.length === 0),
-        disabled: !loading
+        disabled: loading
       }"
       hide-details
       :error="required && (!value || value.length === 0)"
@@ -90,6 +91,7 @@ export default {
           'cursor-pointer': !focused
         }"
         min="1"
+        @disabled="loading"
         @keyup.enter="save"
         @keyup.esc="discard"
         @focus="focused = true"
@@ -148,18 +150,18 @@ export default {
   .v-input {
     color: inherit !important;
     font-size: inherit !important;
-  }
 
-  &.disabled {
-    .v-input {
-      color: #d00 !important;
+    &.disabled {
+      color: #90a4ae !important;
     }
   }
 
   .input-container {
     input,
     input:active {
+      color: inherit !important;
       outline: none;
+      transition: all 100ms;
       width: 100%;
     }
 

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -21,6 +21,10 @@ export default {
     return {
       focused: false,
       isEditing: false,
+      rules: {
+        required: val => !!val || 'Required.',
+        length: val => val?.length > 0 || 'At least one number is required'
+      },
       value: this.content
     }
   },
@@ -54,12 +58,20 @@ export default {
   >
     <v-icon small class="edit-icon">edit</v-icon>
 
-    <div class="input-container">
+    <div
+      class="input-container"
+      :class="{
+        'error-border': !value || value.length === 0
+      }"
+    >
       <input
         ref="edit-input"
         v-model="value"
         class="truncate"
-        :class="{ 'cursor-pointer': !focused }"
+        :class="{
+          'cursor-pointer': !focused
+        }"
+        min="1"
         @disabled="!isEditing"
         @focus="focused = true"
         @keyup.enter="save"
@@ -95,6 +107,14 @@ export default {
   width: 60px;
 }
 
+.edit-icon {
+  left: -20px;
+  opacity: 0;
+  position: absolute;
+  top: 6px;
+  transition: all 150ms;
+}
+
 .inherited-text-field {
   box-sizing: border-box;
   color: inherit !important;
@@ -111,24 +131,31 @@ export default {
     width: 100%;
   }
 
-  .input-container::after {
-    background-color: #3b8dff;
-    bottom: 0;
-    content: '';
-    height: 2px;
-    left: 50%;
-    position: absolute;
-    transition: all 100ms;
-    transition-delay: 100ms;
-    width: 0%;
-  }
+  // .input-container {
+  //   &.error {
+  //     &::after {
+  //       background-color: var(--v-error-base);
+  //     }
+  //   }
+  // }
 
-  .edit-icon {
-    left: -20px;
-    opacity: 0;
-    position: absolute;
-    top: 6px;
-    transition: all 150ms;
+  .input-container {
+    &::after {
+      background-color: #3b8dff;
+      bottom: 0;
+      content: '';
+      height: 2px;
+      left: 50%;
+      position: absolute;
+      transition: all 100ms;
+      transition-delay: 10ms;
+      width: 0%;
+    }
+
+    &.error-border::after {
+      background-color: var(--v-error-base);
+      transition-delay: 0;
+    }
   }
 
   &.focused {

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -40,12 +40,14 @@ export default {
       this.value = this.content
     },
     edit() {
+      if (this.loading) return
+
       this.focused = true
 
       this.$refs['edit-input']?.focus()
     },
     save() {
-      if (this.value?.length === 0) return
+      if (this.loading || this.value?.length === 0) return
 
       this.focused = false
       this.$refs['edit-input']?.blur()
@@ -73,30 +75,49 @@ export default {
       width="2"
     />
 
-    <v-input
-      class="input-container"
-      :class="{
-        'error-border': required && (!value || value.length === 0),
-        disabled: loading
-      }"
-      hide-details
-      :error="required && (!value || value.length === 0)"
-      @disabled="loading"
+    <v-menu
+      :value="focused && required && (!value || value.length === 0)"
+      :close-on-click="false"
+      :open-on-click="false"
+      :close-on-content-click="false"
+      offset-y
+      max-width="320"
+      nudge-bottom="5"
     >
-      <input
-        ref="edit-input"
-        v-model="value"
-        class="truncate"
-        :class="{
-          'cursor-pointer': !focused
-        }"
-        min="1"
-        @disabled="loading"
-        @keyup.enter="save"
-        @keyup.esc="discard"
-        @focus="focused = true"
-      />
-    </v-input>
+      <template #activator="{on}">
+        <v-input
+          class="input-container"
+          :class="{
+            'error-border': required && (!value || value.length === 0),
+            disabled: loading
+          }"
+          hide-details
+          :error="required && (!value || value.length === 0)"
+          v-on="on"
+          @disabled="loading"
+        >
+          <input
+            ref="edit-input"
+            v-model="value"
+            class="truncate"
+            :class="{
+              'cursor-pointer': !focused
+            }"
+            min="1"
+            @disabled="loading"
+            @keyup.enter="save"
+            @keyup.esc="discard"
+            @focus="focused = !loading && true"
+          />
+        </v-input>
+      </template>
+
+      <v-card class="pa-0" max-width="320">
+        <v-card-text>
+          Flow run names can't be empty.
+        </v-card-text>
+      </v-card>
+    </v-menu>
 
     <!-- Not sure if we need to show these buttons since enter is a pretty natural interaction -->
     <!-- <div v-if="focused" class="button-container text-center">
@@ -150,10 +171,6 @@ export default {
   .v-input {
     color: inherit !important;
     font-size: inherit !important;
-
-    &.disabled {
-      color: #90a4ae !important;
-    }
   }
 
   .input-container {
@@ -163,6 +180,15 @@ export default {
       outline: none;
       transition: all 100ms;
       width: 100%;
+    }
+
+    &.disabled {
+      color: #90a4ae !important;
+      cursor: progress;
+
+      input {
+        pointer-events: none;
+      }
     }
 
     &::after {

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -63,22 +63,36 @@ export default {
         @disabled="!isEditing"
         @focus="focused = true"
         @keyup.enter="save"
+        @keyup.esc="discard"
       />
     </div>
 
-    <div v-if="focused" class="button-container">
-      <v-btn depressed x-small class="mr-1" @click="discard">Cancel</v-btn>
-      <v-btn depressed color="primary" x-small @click="save">Save</v-btn>
-    </div>
+    <!-- Not sure if we need to show these buttons since enter is a pretty natural interaction -->
+    <!-- <div v-if="focused" class="button-container text-center">
+      <v-btn block depressed color="primary" x-small @click="save">
+        Save
+      </v-btn>
+      <v-btn
+        block
+        depressed
+        x-small
+        class="mr-1"
+        color="transparent"
+        @click="discard"
+      >
+        Cancel
+      </v-btn>
+    </div> -->
   </div>
 </template>
 
 <style lang="scss" scoped>
 .button-container {
   position: absolute;
-  right: 0;
+  right: -60px;
   top: 50%;
   transform: translate(0, -50%);
+  width: 60px;
 }
 
 .inherited-text-field {

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -15,12 +15,16 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    required: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data() {
     return {
       focused: false,
-      isEditing: false,
       rules: {
         required: val => !!val || 'Required.',
         length: val => val?.length > 0 || 'At least one number is required'
@@ -41,6 +45,8 @@ export default {
       this.$refs['edit-input']?.focus()
     },
     save() {
+      if (this.value?.length === 0) return
+
       this.focused = false
       this.$refs['edit-input']?.blur()
 
@@ -61,7 +67,7 @@ export default {
     <div
       class="input-container"
       :class="{
-        'error-border': !value || value.length === 0
+        'error-border': required && (!value || value.length === 0)
       }"
     >
       <input
@@ -72,7 +78,7 @@ export default {
           'cursor-pointer': !focused
         }"
         min="1"
-        @disabled="!isEditing"
+        @disabled="loading"
         @focus="focused = true"
         @keyup.enter="save"
         @keyup.esc="discard"
@@ -130,14 +136,6 @@ export default {
     outline: none;
     width: 100%;
   }
-
-  // .input-container {
-  //   &.error {
-  //     &::after {
-  //       background-color: var(--v-error-base);
-  //     }
-  //   }
-  // }
 
   .input-container {
     &::after {

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -24,6 +24,7 @@ export default {
   },
   data() {
     return {
+      error: false,
       focused: false,
       rules: {
         required: val => !!val || 'Required.',
@@ -47,6 +48,7 @@ export default {
       this.$refs['edit-input']?.focus()
     },
     save() {
+      this.error = this.value?.length === 0
       if (this.loading || this.value?.length === 0) return
 
       this.focused = false
@@ -76,7 +78,7 @@ export default {
     />
 
     <v-menu
-      :value="focused && required && (!value || value.length === 0)"
+      :value="focused && required && (!value || value.length === 0) && error"
       :close-on-click="false"
       :open-on-click="false"
       :close-on-content-click="false"
@@ -103,7 +105,7 @@ export default {
             :class="{
               'cursor-pointer': !focused
             }"
-            min="1"
+            :placeholder="`${label} (press enter to save)`"
             @disabled="loading"
             @keyup.enter="save"
             @keyup.esc="discard"
@@ -112,11 +114,9 @@ export default {
         </v-input>
       </template>
 
-      <v-card class="pa-0" max-width="320">
-        <v-card-text>
-          Flow run names can't be empty.
-        </v-card-text>
-      </v-card>
+      <v-alert border="left" colored-border type="error" class="ma-0">
+        {{ label }} can't be empty
+      </v-alert>
     </v-menu>
 
     <!-- Not sure if we need to show these buttons since enter is a pretty natural interaction -->

--- a/src/components/EditableTextField.vue
+++ b/src/components/EditableTextField.vue
@@ -1,0 +1,137 @@
+<script>
+export default {
+  props: {
+    content: {
+      type: String,
+      required: false,
+      default: () => null
+    },
+    label: {
+      type: String,
+      required: false,
+      default: () => null
+    },
+    loading: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  data() {
+    return {
+      focused: false,
+      isEditing: false,
+      value: this.content
+    }
+  },
+  methods: {
+    discard() {
+      this.isEditing = false
+
+      this.value = this.content
+    },
+    edit() {
+      this.isEditing = true
+      console.log(this.$refs)
+      this.$refs['edit-input']?.focus()
+    },
+    save() {
+      this.isEditing = false
+
+      this.$emit('change', this.value)
+    }
+  }
+}
+</script>
+
+<template>
+  <div
+    v-click-outside="discard"
+    class="inherited-text-field"
+    :class="{ focused: focused, 'cursor-pointer': !focused }"
+  >
+    <v-icon small class="edit-icon">edit</v-icon>
+
+    <div class="input-container">
+      <input
+        ref="edit-input"
+        v-model="value"
+        class="truncate"
+        :class="{ 'cursor-pointer': !focused }"
+        @disabled="!isEditing"
+        @focus="focused = true"
+        @blur="focused = false"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.edit-icon {
+  float: right;
+}
+
+.original-border {
+  border: 1px solid #ddd;
+}
+
+.inherited-text-field {
+  box-sizing: border-box;
+  color: inherit !important;
+  font-size: inherit !important;
+  height: 30px;
+  max-width: 100%;
+  padding-bottom: 2px;
+  position: relative;
+  width: fit-content;
+
+  input,
+  input:active {
+    outline: none;
+    width: auto;
+  }
+
+  .input-container::after {
+    background-color: #3b8dff;
+    bottom: 0;
+    content: '';
+    height: 2px;
+    left: 50%;
+    position: absolute;
+    transition: all 100ms;
+    transition-delay: 100ms;
+    width: 0%;
+  }
+
+  .edit-icon {
+    left: -20px;
+    opacity: 0;
+    position: absolute;
+    top: 6px;
+    transition: all 150ms;
+  }
+
+  &.focused {
+    .input-container {
+      border-bottom: 1px solid #ddd;
+      height: 100%;
+    }
+
+    .input-container::after {
+      left: 0;
+      width: 100%;
+    }
+
+    .edit-icon {
+      opacity: 1;
+    }
+  }
+
+  &:focus,
+  &:hover {
+    .edit-icon {
+      opacity: 1;
+    }
+  }
+}
+</style>

--- a/src/components/JsonInput.vue
+++ b/src/components/JsonInput.vue
@@ -179,15 +179,15 @@ export default {
       class="ma-1 pt-2 cm-style"
       :class="{
         'pl-7': prependIcon,
-        'blue-border': prependIcon && focused && !jsonError,
+        'blue-border': prependIcon && focussed && !jsonError,
         'red-border': prependIcon && jsonError,
-        'plain-border': prependIcon && !focused && !jsonError,
+        'plain-border': prependIcon && !focussed && !jsonError,
         'original-border': !prependIcon
       }"
       :options="editorOptions"
       @input="handleJsonInput($event)"
-      @focus="focused = true"
-      @blur="focused = false"
+      @focus="focussed = true"
+      @blur="focussed = false"
     ></CodeMirror>
 
     <slot></slot>

--- a/src/components/JsonInput.vue
+++ b/src/components/JsonInput.vue
@@ -179,15 +179,15 @@ export default {
       class="ma-1 pt-2 cm-style"
       :class="{
         'pl-7': prependIcon,
-        'blue-border': prependIcon && focussed && !jsonError,
+        'blue-border': prependIcon && focused && !jsonError,
         'red-border': prependIcon && jsonError,
-        'plain-border': prependIcon && !focussed && !jsonError,
+        'plain-border': prependIcon && !focused && !jsonError,
         'original-border': !prependIcon
       }"
       :options="editorOptions"
       @input="handleJsonInput($event)"
-      @focus="focussed = true"
-      @blur="focussed = false"
+      @focus="focused = true"
+      @blur="focused = false"
     ></CodeMirror>
 
     <slot></slot>

--- a/src/graphql/Mutations/set-flow-run-name.gql
+++ b/src/graphql/Mutations/set-flow-run-name.gql
@@ -1,0 +1,6 @@
+mutation SetFlowRunName($input: set_flow_run_name_input!) {
+  set_flow_run_name(input: $input) {
+    success
+    error
+  }
+}

--- a/src/layouts/SubPageNav.vue
+++ b/src/layouts/SubPageNav.vue
@@ -16,7 +16,7 @@
             cols="12"
             class="d-flex align-center justify-space-between pb-1"
           >
-            <div>
+            <div style="width: inherit;">
               <div class="overline"><slot name="page-type"></slot></div>
               <div class="headline"><slot name="page-title"></slot></div>
             </div>

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -4,6 +4,7 @@ import { mapGetters } from 'vuex'
 import Actions from '@/pages/FlowRun/Actions'
 import BreadCrumbs from '@/components/BreadCrumbs'
 import DetailsTile from '@/pages/FlowRun/Details-Tile'
+import EditableTextField from '@/components/EditableTextField'
 import ExternalLink from '@/components/ExternalLink'
 import TimelineTile from '@/pages/FlowRun/Timeline-Tile'
 import LogsCard from '@/components/LogsCard/LogsCard'
@@ -37,6 +38,7 @@ export default {
     Actions,
     BreadCrumbs,
     DetailsTile,
+    EditableTextField,
     ExternalLink,
     TimelineTile,
     LogsCard,
@@ -104,6 +106,9 @@ export default {
     },
     parseMarkdown(md) {
       return parser(md)
+    },
+    saveFlowRunName(e) {
+      console.log(e)
     }
   },
   apollo: {
@@ -128,7 +133,11 @@ export default {
     <SubPageNav>
       <span slot="page-type">Flow Run</span>
       <span slot="page-title">
-        {{ flowRun.name }}
+        <EditableTextField
+          :content="flowRun.name"
+          label="Flow Run Name"
+          @change="saveFlowRunName"
+        />
       </span>
 
       <BreadCrumbs

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -111,7 +111,7 @@ export default {
     },
     async saveFlowRunName(e) {
       try {
-        const previousName = this.flowRunName
+        const previousName = this.flowRun.name
         this.flowRunNameLoading = true
 
         const { data } = await this.$apollo.mutate({

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -145,9 +145,7 @@ export default {
           alertType: 'error'
         })
       } finally {
-        setTimeout(() => {
-          this.flowRunNameLoading = false
-        }, 3000)
+        this.flowRunNameLoading = false
       }
     }
   },
@@ -183,7 +181,7 @@ export default {
       >
         <EditableTextField
           :content="flowRun.name"
-          label="Flow Run Name"
+          label="Flow run name"
           :loading="flowRunNameLoading"
           required
           @change="saveFlowRunName"

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -168,7 +168,15 @@ export default {
   <v-sheet v-if="flowRun" color="appBackground">
     <SubPageNav>
       <span slot="page-type">Flow Run</span>
-      <span slot="page-title">
+      <span
+        slot="page-title"
+        style="
+        display: block;
+        max-width: 50%;
+        min-width: 500px;
+        width: auto;
+        "
+      >
         <EditableTextField
           :content="flowRun.name"
           label="Flow Run Name"

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -145,7 +145,9 @@ export default {
           alertType: 'error'
         })
       } finally {
-        this.flowRunNameLoading = false
+        setTimeout(() => {
+          this.flowRunNameLoading = false
+        }, 3000)
       }
     }
   },

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -183,6 +183,7 @@ export default {
           :content="flowRun.name"
           label="Flow Run Name"
           :loading="flowRunNameLoading"
+          required
           @change="saveFlowRunName"
         />
       </span>

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -110,8 +110,10 @@ export default {
       return parser(md)
     },
     async saveFlowRunName(e) {
+      const previousName = this.flowRun.name
+      if (previousName === e) return
+
       try {
-        const previousName = this.flowRun.name
         this.flowRunNameLoading = true
 
         const { data } = await this.$apollo.mutate({
@@ -132,7 +134,7 @@ export default {
 
         this.setAlert({
           alertShow: true,
-          alertMessage: `${previousName} has been renamed to ${e}`,
+          alertMessage: `<span class="font-weight-medium">${previousName}</span> has been renamed to <span class="font-weight-medium">${e}</span>`,
           alertType: 'success'
         })
       } catch {
@@ -172,8 +174,8 @@ export default {
         slot="page-title"
         style="
         display: block;
-        max-width: 50%;
-        min-width: 500px;
+        max-width: 100%;
+        min-width: 300px;
         width: auto;
         "
       >


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Enables modifying flow run names directly from the flow run page:
![Nov-17-2020 13-14-15](https://user-images.githubusercontent.com/27291717/99430161-f85eb200-28d6-11eb-8d29-98f9778d4d8a.gif)


Also introduces a new "editable field" component, which is a drop-in alternative to `v-input` meant to maintain inline styling while allowing modification _without_ using `contenteditable` (which doesn't work with many Vue-related APIs)