### PR TITLE
Fix schematic node finished task run durations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 ### Bugfixes
 
 - Fix an issue where restarting a task run would fail to correctly set downstream task run states - [#452](https://github.com/PrefectHQ/ui/pull/452)
+- Fix schematic node finished task run durations - [#468](https://github.com/PrefectHQ/ui/pull/468)
 
 ## 2020-11-13
 

--- a/src/components/Schematics/Schematic-Node.vue
+++ b/src/components/Schematics/Schematic-Node.vue
@@ -3,6 +3,7 @@ import { duration } from '@/utils/moment'
 import DurationSpan from '@/components/DurationSpan'
 import StackedLineChart from '@/components/Visualizations/StackedLineChart'
 import { STATE_COLORS } from '@/utils/states'
+import { FINISHED_STATES } from '@/utils/states'
 
 export default {
   filters: {
@@ -146,6 +147,9 @@ export default {
         green10 = parseInt(green, 16),
         blue10 = parseInt(blue, 16)
       return `rgba(${red10}, ${green10}, ${blue10}, 0.6)`
+    },
+    isFinished(state) {
+      return FINISHED_STATES.includes(state)
     }
   },
   apollo: {
@@ -209,7 +213,13 @@ export default {
         Duration:
         <DurationSpan
           :start-time="nodeData.data.start_time"
-          :end-time="nodeData.data.end_time"
+          :end-time="
+            nodeData.data.end_time
+              ? nodeData.data.end_time
+              : isFinished(nodeData.data.state)
+              ? nodeData.data.start_time
+              : null
+          "
         />
       </div>
     </div>


### PR DESCRIPTION

PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds some conditional logic to schematic node duration calculations. This resolves cases where a task runs in finished states that have their `start_time` field populated but no `end_time` had runaway durations based on the current time.

Resolves: #464 