### PR TITLE
Remove decrossing from schematic calculations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Assorted visual bugs - [#507](https://github.com/PrefectHQ/ui/pull/507)
 - Remove disabled from the artifacts tab on mobile pages - [#512](https://github.com/PrefectHQ/ui/pull/512)
 - Route to the 404 page if an incomplete or incorrect flow run, task or task run uuid is given in the route - [#511](https://github.com/PrefectHQ/ui/pull/511)
+- Remove decrossing from schematic graph calculations - [#515](https://github.com/PrefectHQ/ui/pull/515)
 
 ## 2020-12-14
 

--- a/src/workers/schematic.js
+++ b/src/workers/schematic.js
@@ -75,7 +75,7 @@ export function GenerateLayout(data) {
       .sugiyama()
       .size([width - canvasAdjustment.w, height - canvasAdjustment.h])
       .layering(d3.layeringLongestPath().topDown(false))
-      .decross(d3.decrossTwoLayer().order(d3.twolayerOpt()))
+      // .decross(d3.decrossTwoLayer().order(d3.twolayerOpt())) // Disabling this due to runaway worker memory usage for large graphs
       // .coord(d3.coordMinCurve()) // Disabling this due to some edge cases with quadratic positive definites
       .separation((a, b) => {
         return (a.data !== undefined) + (b.data !== undefined)


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes an issue where the decrossing large graphs was leading to runaway memory usage in the schematic worker. Note: this will lead to some differences in task ordering and the RTL state of some graphs but overall should have very little impact. 

cc: @josephsmith 