### PR TITLE
Flow Group schedule timezones

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Adds the timezone field to the set_flow_group_schedule mutation to allow the clocks to be set to the user's desired timezone - [#532](https://github.com/PrefectHQ/ui/pull/532)
 
 ## 2021-01-19
 

--- a/src/components/Functional/CronClock.vue
+++ b/src/components/Functional/CronClock.vue
@@ -13,6 +13,11 @@ export default {
       type: Boolean,
       required: false,
       default: () => false
+    },
+    timezone: {
+      type: String,
+      required: false,
+      default: null
     }
   },
   computed: {
@@ -30,5 +35,8 @@ export default {
 </script>
 
 <template>
-  <span v-html="highlightedText"></span>
+  <div>
+    <span v-html="highlightedText"></span>
+    <span class="primary--text"> ({{ timezone }})</span>
+  </div>
 </template>

--- a/src/components/Functional/CronClock.vue
+++ b/src/components/Functional/CronClock.vue
@@ -26,9 +26,17 @@ export default {
     },
     highlightedText() {
       if (!this.parsedCron) return ''
-      return this.parsedCron.replace(PARSED_SCHEDULE_REGEX, match => {
-        return `<span class="primary--text">${match}</span>`
-      })
+      if (this.timezone) {
+        return this.parsedCron
+          .replace(PARSED_SCHEDULE_REGEX, match => {
+            return `<span class="primary--text">${match}</span>`
+          })
+          .concat(`<span class="primary--text"> (${this.timezone})</span>`)
+      } else {
+        return this.parsedCron.replace(PARSED_SCHEDULE_REGEX, match => {
+          return `<span class="primary--text">${match}</span>`
+        })
+      }
     }
   }
 }

--- a/src/components/Functional/CronClock.vue
+++ b/src/components/Functional/CronClock.vue
@@ -1,6 +1,7 @@
 <script>
 /* eslint-disable vue/no-v-html */
 import cronstrue from 'cronstrue'
+import moment from 'moment-timezone'
 import { PARSED_SCHEDULE_REGEX } from '@/utils/regEx'
 
 export default {
@@ -24,6 +25,11 @@ export default {
     parsedCron() {
       return cronstrue.toString(this.cron, { verbose: this.verbose })
     },
+    timezoneAbbr() {
+      return moment()
+        .tz(this.timezone)
+        .zoneAbbr()
+    },
     highlightedText() {
       if (!this.parsedCron) return ''
       if (this.timezone) {
@@ -31,7 +37,7 @@ export default {
           .replace(PARSED_SCHEDULE_REGEX, match => {
             return `<span class="primary--text">${match}</span>`
           })
-          .concat(`<span class="primary--text"> (${this.timezone})</span>`)
+          .concat(`<span class="primary--text"> (${this.timezoneAbbr})</span>`)
       } else {
         return this.parsedCron.replace(PARSED_SCHEDULE_REGEX, match => {
           return `<span class="primary--text">${match}</span>`

--- a/src/components/Functional/CronClock.vue
+++ b/src/components/Functional/CronClock.vue
@@ -35,8 +35,5 @@ export default {
 </script>
 
 <template>
-  <div>
-    <span v-html="highlightedText"></span>
-    <span class="primary--text"> ({{ timezone }})</span>
-  </div>
+  <span v-html="highlightedText"></span>
 </template>

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -119,30 +119,21 @@ export default {
           </v-chip-group>
 
           <v-fade-transition mode="out-in">
-            <CronForm
-              v-if="advancedType == 'cron'"
-              key="Cron"
-              v-model="cronModel"
-              :valid.sync="valid"
-              class="mt-4"
-            />
-            <IntervalForm
-              v-else-if="advancedType == 'interval'"
-              key="Interval"
-              v-model="intervalModel"
-              class="mt-4"
-            />
+            <div v-if="advancedType == 'cron'" key="Cron">
+              <CronForm v-model="cronModel" :valid.sync="valid" class="mt-4" />
+              <v-autocomplete
+                v-model="selectedTimezone"
+                :items="tzs"
+                outlined
+                label="Time Zone"
+                style="margin-top: 110px;"
+                prepend-inner-icon="access_time"
+              />
+            </div>
+            <div v-else-if="advancedType == 'interval'" key="Interval">
+              <IntervalForm v-model="intervalModel" class="mt-4" />
+            </div>
           </v-fade-transition>
-
-          <v-autocomplete
-            v-show="advancedType == 'cron'"
-            v-model="selectedTimezone"
-            :items="tzs"
-            outlined
-            label="Time Zone"
-            style="margin-top: 150px;"
-            prepend-inner-icon="access_time"
-          />
         </div>
         <div v-else key="2" class="mt-4 d-block" style="max-width: 100%;">
           <SimpleForm v-model="simpleModel" />

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -134,14 +134,16 @@ export default {
             />
           </v-fade-transition>
 
-          <!-- <v-select
-            v-if="advancedType == 'cron'"
+          <v-autocomplete
+            v-show="advancedType == 'cron'"
             v-model="selectedTimezone"
-            style="margin-top: 100px;"
             :items="tzs"
-            label="Time Zone (Optional)"
+            label="Time Zone"
+            style="margin-top: 150px;"
+            outlined
             prepend-inner-icon="access_time"
-          ></v-select> -->
+            :menu-props="{ offsetY: true }"
+          />
         </div>
         <div v-else key="2" class="mt-4 d-block" style="max-width: 100%;">
           <SimpleForm v-model="simpleModel" />

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -35,7 +35,7 @@ export default {
   data() {
     return {
       tzs: [...moment.tz.names()],
-      selectedTimezone: null,
+      selectedTimezone: this.timezone,
       advanced: false,
       // Sets the default advanced tab
       // if a certain type was specific
@@ -56,9 +56,6 @@ export default {
     clockToAdd() {
       return this.advanced ? `${this.advancedType}Model` : 'simpleModel'
     }
-  },
-  beforeMount() {
-    this.selectedTimezone = this.timezone
   },
   methods: {
     cancel() {

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -140,9 +140,7 @@ export default {
             :items="tzs"
             label="Time Zone"
             style="margin-top: 150px;"
-            outlined
             prepend-inner-icon="access_time"
-            :menu-props="{ offsetY: true }"
           />
         </div>
         <div v-else key="2" class="mt-4 d-block" style="max-width: 100%;">
@@ -168,3 +166,10 @@ export default {
     </div>
   </v-container>
 </template>
+
+<style>
+/* stylelint-disable */
+.v-autocomplete__content.v-menu__content .v-select-list {
+  max-width: 100%;
+}
+</style>

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -135,8 +135,9 @@ export default {
           </v-fade-transition>
 
           <v-select
+            v-if="advancedType == 'cron'"
             v-model="selectedTimezone"
-            outlined
+            style="margin-top: 80px;"
             :items="tzs"
             label="Time Zone (Optional)"
             prepend-inner-icon="access_time"

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -137,7 +137,8 @@ export default {
           <v-select
             v-if="advancedType == 'cron'"
             v-model="selectedTimezone"
-            style="margin-top: 80px;"
+            style="margin-top: 120px;"
+            outlined
             :items="tzs"
             label="Time Zone (Optional)"
             prepend-inner-icon="access_time"

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -138,6 +138,7 @@ export default {
             v-show="advancedType == 'cron'"
             v-model="selectedTimezone"
             :items="tzs"
+            outlined
             label="Time Zone"
             style="margin-top: 150px;"
             prepend-inner-icon="access_time"

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -4,6 +4,10 @@ import IntervalForm from '@/pages/Flow/Settings/ClockForms/Interval'
 import SimpleForm from '@/pages/Flow/Settings/ClockForms/Simple'
 import moment from 'moment-timezone'
 
+const timezones = [...moment.tz.names()].map(tz => {
+  return { text: tz.replace(/_/g, ' '), value: tz }
+})
+
 export default {
   components: {
     CronForm,
@@ -34,7 +38,7 @@ export default {
   },
   data() {
     return {
-      tzs: [...moment.tz.names()],
+      tzs: timezones,
       selectedTimezone: this.timezone,
       advanced: false,
       // Sets the default advanced tab

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -138,7 +138,6 @@ export default {
             v-if="advancedType == 'cron'"
             v-model="selectedTimezone"
             style="margin-top: 120px;"
-            outlined
             :items="tzs"
             label="Time Zone (Optional)"
             prepend-inner-icon="access_time"

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -134,14 +134,14 @@ export default {
             />
           </v-fade-transition>
 
-          <v-select
+          <!-- <v-select
             v-if="advancedType == 'cron'"
             v-model="selectedTimezone"
-            style="margin-top: 120px;"
+            style="margin-top: 100px;"
             :items="tzs"
             label="Time Zone (Optional)"
             prepend-inner-icon="access_time"
-          ></v-select>
+          ></v-select> -->
         </div>
         <div v-else key="2" class="mt-4 d-block" style="max-width: 100%;">
           <SimpleForm v-model="simpleModel" />

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -2,6 +2,7 @@
 import CronForm from '@/pages/Flow/Settings/ClockForms/Cron'
 import IntervalForm from '@/pages/Flow/Settings/ClockForms/Interval'
 import SimpleForm from '@/pages/Flow/Settings/ClockForms/Simple'
+import moment from 'moment-timezone'
 
 export default {
   components: {
@@ -28,6 +29,8 @@ export default {
   },
   data() {
     return {
+      tzs: [...moment.tz.names()],
+      selectedTimezone: null,
       advanced: false,
       // Sets the default advanced tab
       // if a certain type was specific
@@ -61,9 +64,9 @@ export default {
         type: clockType,
         [clockType == 'IntervalClock' ? 'interval' : 'cron']: this[
           this.clockToAdd
-        ]
+        ],
+        timezone: this.selectedTimezone
       }
-
       this.$emit('confirm', clock)
     }
   }
@@ -130,6 +133,14 @@ export default {
               class="mt-4"
             />
           </v-fade-transition>
+
+          <v-select
+            v-model="selectedTimezone"
+            outlined
+            :items="tzs"
+            label="Time Zone (Optional)"
+            prepend-inner-icon="access_time"
+          ></v-select>
         </div>
         <div v-else key="2" class="mt-4 d-block" style="max-width: 100%;">
           <SimpleForm v-model="simpleModel" />

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -57,6 +57,9 @@ export default {
       return this.advanced ? `${this.advancedType}Model` : 'simpleModel'
     }
   },
+  beforeMount() {
+    this.selectedTimezone = this.timezone
+  },
   methods: {
     cancel() {
       this.$emit('cancel')
@@ -74,9 +77,6 @@ export default {
       }
       this.$emit('confirm', clock)
     }
-  },
-  beforeMount() {
-    this.selectedTimezone = this.timezone
   }
 }
 </script>
@@ -136,6 +136,7 @@ export default {
                 label="Time Zone"
                 style="margin-top: 110px;"
                 prepend-inner-icon="access_time"
+                :menu-props="{ contentClass: 'tz' }"
               />
             </div>
             <div v-else-if="advancedType == 'interval'" key="Interval">
@@ -169,7 +170,7 @@ export default {
 
 <style>
 /* stylelint-disable */
-.v-autocomplete__content.v-menu__content .v-select-list {
+.tz.v-menu__content .v-select-list {
   max-width: 100%;
 }
 </style>

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -25,6 +25,11 @@ export default {
       type: String,
       required: false,
       default: () => 'New Schedule'
+    },
+    timezone: {
+      type: String,
+      required: false,
+      default: null
     }
   },
   data() {
@@ -69,6 +74,9 @@ export default {
       }
       this.$emit('confirm', clock)
     }
+  },
+  beforeMount() {
+    this.selectedTimezone = this.timezone
   }
 }
 </script>

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -143,10 +143,10 @@ export default {
                 flow_group_id: this.flowGroup.id,
                 cron_clocks: cronClocks,
                 interval_clocks: intervalClocks,
-                timezone:
-                  this.clocks[0]?.timezone || this.timezone !== ''
-                    ? this.timezone
-                    : Intl.DateTimeFormat().resolvedOptions().timeZone
+                timezone: this.clocks[0]?.timezone
+                  ? this.clocks[0]?.timezone
+                  : this.timezone ||
+                    Intl.DateTimeFormat().resolvedOptions().timeZone
               }
             }
           })
@@ -189,9 +189,13 @@ export default {
       }
     },
     timezoneVal(clock) {
-      return clock?.timezone || clock?.start_date?.tz || this.timezone !== ''
-        ? this.timezone
-        : Intl.DateTimeFormat().resolvedOptions().timeZone
+      let tz = this.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+      if (clock?.timezone) {
+        tz = clock?.timezone
+      } else if (clock?.start_date?.tz) {
+        tz = clock?.start_date?.tz
+      }
+      return tz
     }
   }
 }

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -1,5 +1,6 @@
 <script>
-import { mapActions } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
+import moment from 'moment-timezone'
 
 import ConfirmDialog from '@/components/ConfirmDialog'
 import CronClock from '@/components/Functional/CronClock'
@@ -37,6 +38,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters('user', ['timezone']),
     flowClocks() {
       return this.flow.schedule?.clocks.map(c => {
         // This is so we know where each clock originates while allowing us to put them in a single array
@@ -50,6 +52,11 @@ export default {
         c.scheduleType = 'flow-group'
         return c
       })
+    },
+    timezoneAbbr() {
+      return moment()
+        .tz(this.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone)
+        .zoneAbbr()
     }
   },
   watch: {
@@ -141,7 +148,10 @@ export default {
               input: {
                 flow_group_id: this.flowGroup.id,
                 cron_clocks: cronClocks,
-                interval_clocks: intervalClocks
+                interval_clocks: intervalClocks,
+                timezone:
+                  this.timezone ||
+                  Intl.DateTimeFormat().resolvedOptions().timeZone
               }
             }
           })
@@ -301,6 +311,7 @@ export default {
                     <CronClock
                       v-if="clock.type == 'CronClock'"
                       :cron="clock.cron"
+                      :timezone="timezoneAbbr"
                     />
                     <IntervalClock
                       v-else-if="clock.type == 'IntervalClock'"

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -55,7 +55,7 @@ export default {
     },
     timezoneAbbr() {
       return moment()
-        .tz(this.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone)
+        .tz(this.clocks[0].timezone || this.timezone)
         .zoneAbbr()
     }
   },

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -143,7 +143,7 @@ export default {
                 flow_group_id: this.flowGroup.id,
                 cron_clocks: cronClocks,
                 interval_clocks: intervalClocks,
-                timezone: this.clocks[0].timezone || this.timezone
+                timezone: this.clocks[0]?.timezone || this.timezone
               }
             }
           })
@@ -184,6 +184,9 @@ export default {
           alertType: 'error'
         })
       }
+    },
+    timezoneVal(clock) {
+      return clock?.timezone || clock?.start_date?.tz || this.timezone
     }
   }
 }
@@ -282,6 +285,7 @@ export default {
               <ClockForm
                 :cron="clock.cron"
                 :interval="clock.interval"
+                :timezone="timezoneVal(clock)"
                 title="Modify schedule"
                 @cancel="selectedClock = null"
                 @confirm="createClock"
@@ -303,7 +307,7 @@ export default {
                     <CronClock
                       v-if="clock.type == 'CronClock'"
                       :cron="clock.cron"
-                      :timezone="clocks[0].timezone || timezone"
+                      :timezone="timezoneVal(clock)"
                     />
                     <IntervalClock
                       v-else-if="clock.type == 'IntervalClock'"

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -1,6 +1,5 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import moment from 'moment-timezone'
 
 import ConfirmDialog from '@/components/ConfirmDialog'
 import CronClock from '@/components/Functional/CronClock'
@@ -52,11 +51,6 @@ export default {
         c.scheduleType = 'flow-group'
         return c
       })
-    },
-    timezoneAbbr() {
-      return moment()
-        .tz(this.clocks[0].timezone || this.timezone)
-        .zoneAbbr()
     }
   },
   watch: {
@@ -309,7 +303,7 @@ export default {
                     <CronClock
                       v-if="clock.type == 'CronClock'"
                       :cron="clock.cron"
-                      :timezone="timezoneAbbr"
+                      :timezone="clocks[0].timezone || timezone"
                     />
                     <IntervalClock
                       v-else-if="clock.type == 'IntervalClock'"

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -143,7 +143,10 @@ export default {
                 flow_group_id: this.flowGroup.id,
                 cron_clocks: cronClocks,
                 interval_clocks: intervalClocks,
-                timezone: this.clocks[0]?.timezone || this.timezone
+                timezone:
+                  this.clocks[0]?.timezone || this.timezone !== ''
+                    ? this.timezone
+                    : Intl.DateTimeFormat().resolvedOptions().timeZone
               }
             }
           })
@@ -186,7 +189,9 @@ export default {
       }
     },
     timezoneVal(clock) {
-      return clock?.timezone || clock?.start_date?.tz || this.timezone
+      return clock?.timezone || clock?.start_date?.tz || this.timezone !== ''
+        ? this.timezone
+        : Intl.DateTimeFormat().resolvedOptions().timeZone
     }
   }
 }

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -149,9 +149,7 @@ export default {
                 flow_group_id: this.flowGroup.id,
                 cron_clocks: cronClocks,
                 interval_clocks: intervalClocks,
-                timezone:
-                  this.timezone ||
-                  Intl.DateTimeFormat().resolvedOptions().timeZone
+                timezone: this.clocks[0].timezone || this.timezone
               }
             }
           })


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds the `timezone` field to the `set_flow_group_schedule` mutation to allow the clocks to be set to the user's current timezone