### PR TITLE
don't show 'none' in details tile if flowgroup has a schedule

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix bug where some flows with schedules were showing None in details card - [#553](https://github.com/PrefectHQ/ui/pull/553)
 
 ## 2021-01-07
 

--- a/src/pages/Flow/Details-Tile.vue
+++ b/src/pages/Flow/Details-Tile.vue
@@ -227,8 +227,8 @@ export default {
               </v-list-item-subtitle>
               <div class="subtitle-2">
                 <PrefectSchedule
-                  v-if="flow.schedule"
-                  :schedule="flow.schedule"
+                  v-if="flow.schedule || flowGroup.schedule"
+                  :schedule="flow.schedule ? flow.schedule : flowGroup.schedule"
                 />
                 <span v-else>None</span>
               </div>


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
noticed that my flow, which has a schedule, was showing "none" in the details tile. this should fix it, I think