### PR TITLE
Add new date method to prevent over-querying

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,11 +4,13 @@
 
 ### Features and Improvements
 
-- None
+- Improve dashboard and flow page query performance - [#558](https://github.com/PrefectHQ/ui/pull/558)
+- Hard-cap dashboard timeline queries to 1 month out (improves performance) - [#558](https://github.com/PrefectHQ/ui/pull/558)
 
 ### Bugfixes
 
 - Fix bug where some flows with schedules were showing None in details card - [#553](https://github.com/PrefectHQ/ui/pull/553)
+- Fix an issue with task error pane stuttering every few seconds - [#558](https://github.com/PrefectHQ/ui/pull/558)
 
 ## 2021-01-07
 

--- a/src/graphql/Dashboard/flow-runs.gql
+++ b/src/graphql/Dashboard/flow-runs.gql
@@ -2,7 +2,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Success: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Success" }
     }
   ) {
@@ -13,7 +13,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Running: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Running" }
     }
   ) {
@@ -24,7 +24,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Pending: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Pending" }
     }
   ) {
@@ -35,7 +35,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Failed: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Failed" }
     }
   ) {
@@ -46,7 +46,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   ClientFailed: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "ClientFailed" }
     }
   ) {
@@ -57,7 +57,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Submitted: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Submitted" }
     }
   ) {
@@ -68,7 +68,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Queued: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Queued" }
     }
   ) {
@@ -79,7 +79,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Resume: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Resume" }
     }
   ) {
@@ -90,7 +90,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Retrying: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Retrying" }
     }
   ) {
@@ -101,7 +101,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Looped: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Looped" }
     }
   ) {
@@ -112,7 +112,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Cached: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Cached" }
     }
   ) {
@@ -123,7 +123,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Mapped: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Mapped" }
     }
   ) {
@@ -134,7 +134,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   TimedOut: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "TimedOut" }
     }
   ) {
@@ -145,7 +145,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   TriggerFailed: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "TriggerFailed" }
     }
   ) {
@@ -156,7 +156,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Skipped: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Skipped" }
     }
   ) {
@@ -167,7 +167,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Finished: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Finished" }
     }
   ) {
@@ -178,7 +178,7 @@ query FlowRuns($projectId: uuid, $heartbeat: timestamptz) {
   Cancelled: flow_run_aggregate(
     where: {
       flow: { project_id: { _eq: $projectId } }
-      updated: { _gte: $heartbeat }
+      scheduled_start_time: { _gte: $heartbeat }
       state: { _eq: "Cancelled" }
     }
   ) {

--- a/src/graphql/Dashboard/timeline-flow-runs.gql
+++ b/src/graphql/Dashboard/timeline-flow-runs.gql
@@ -1,8 +1,9 @@
-query TimelineFlowRuns($limit: Int, $project_id: uuid) {
+query TimelineFlowRuns($limit: Int, $project_id: uuid, $date: timestamptz) {
   flow_run(
     where: {
       flow: { project_id: { _eq: $project_id } }
       state: { _neq: "Scheduled" }
+      scheduled_start_time: { _gte: $date }
     }
     limit: $limit
     order_by: { scheduled_start_time: desc }

--- a/src/pages/Dashboard/FailedFlows-Tile.vue
+++ b/src/pages/Dashboard/FailedFlows-Tile.vue
@@ -1,6 +1,6 @@
 <script>
 import { mapGetters } from 'vuex'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 import CardTitle from '@/components/Card-Title'
 import { formatTime } from '@/mixins/formatTimeMixin'
 
@@ -69,7 +69,7 @@ export default {
       variables() {
         return {
           projectId: this.projectId ? this.projectId : null,
-          heartbeat: oneAgo(this.selectedDateFilter)
+          heartbeat: roundedOneAgo(this.selectedDateFilter)
         }
       },
       loadingKey: 'loading',

--- a/src/pages/Dashboard/FailedTasks-Tile.vue
+++ b/src/pages/Dashboard/FailedTasks-Tile.vue
@@ -1,6 +1,6 @@
 <script>
 import { mapGetters } from 'vuex'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 import CardTitle from '@/components/Card-Title'
 import TaskItem from '@/pages/Dashboard/Task-Item'
 import { formatTime } from '@/mixins/formatTimeMixin'
@@ -93,7 +93,7 @@ export default {
       query: require('@/graphql/Dashboard/task-failures.gql'),
       variables() {
         return {
-          heartbeat: oneAgo(this.selectedDateFilter)
+          heartbeat: roundedOneAgo(this.selectedDateFilter)
         }
       },
       loadingKey: 'loading',

--- a/src/pages/Dashboard/FlowRunHeartbeat-Tile.vue
+++ b/src/pages/Dashboard/FlowRunHeartbeat-Tile.vue
@@ -3,7 +3,7 @@ import CardTitle from '@/components/Card-Title'
 import HeartbeatTimeline from '@/components/HeartbeatTimeline'
 import { heartbeatMixin } from '@/mixins/heartbeatMixin.js'
 import { mapGetters } from 'vuex'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 
 export default {
   components: { CardTitle, HeartbeatTimeline },
@@ -41,7 +41,7 @@ export default {
       variables() {
         return {
           projectId: this.projectId ? this.projectId : null,
-          timestamp: oneAgo('month'),
+          timestamp: roundedOneAgo('month'),
           state: this.checkedState,
           filterOutStates: 'Scheduled'
         }

--- a/src/pages/Dashboard/FlowRunHistory-Tile.vue
+++ b/src/pages/Dashboard/FlowRunHistory-Tile.vue
@@ -2,6 +2,7 @@
 import BarChart from '@/components/Visualizations/BarChart.vue'
 import { flowRunHistoryMixin } from '@/mixins/flowRunHistoryMixin'
 import TimelineTooltip from '@/components/TimelineTooltip'
+import { roundedOneAgo } from '@/utils/dateTime'
 
 export default {
   components: {
@@ -40,7 +41,8 @@ export default {
       variables() {
         return {
           limit: this.scheduledFlowRuns?.length === 0 ? 100 : 90,
-          project_id: this.projectId == '' ? null : this.projectId
+          project_id: this.projectId == '' ? null : this.projectId,
+          date: roundedOneAgo('month')
         }
       },
       pollInterval: 5000,
@@ -72,7 +74,7 @@ export default {
       v-if="!loading && reversedRuns.length === 0"
       class="caption text-center grey--text timeline-no-runs"
     >
-      No run history
+      No run history in the last month
     </div>
     <BarChart
       :loading="loading"

--- a/src/pages/Dashboard/Summary-Tile.vue
+++ b/src/pages/Dashboard/Summary-Tile.vue
@@ -2,7 +2,7 @@
 import CardTitle from '@/components/Card-Title'
 import StackedLineChart from '@/components/Visualizations/StackedLineChart'
 import { STATE_COLORS, STATE_PAST_TENSE } from '@/utils/states'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -96,7 +96,7 @@ export default {
       variables() {
         return {
           projectId: this.projectId ? this.projectId : null,
-          heartbeat: oneAgo(this.selectedDateFilter)
+          heartbeat: roundedOneAgo(this.selectedDateFilter)
         }
       },
       pollInterval: 3000,

--- a/src/pages/Flow/Errors-Tile.vue
+++ b/src/pages/Flow/Errors-Tile.vue
@@ -1,7 +1,7 @@
 <script>
 import CardTitle from '@/components/Card-Title'
 import { mapGetters } from 'vuex'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 import moment from '@/utils/moment'
 
 export default {
@@ -88,7 +88,9 @@ export default {
     errors: {
       query: require('@/graphql/Flow/errors.gql'),
       variables() {
-        let variables = { updated: { _gte: oneAgo(this.selectedDateFilter) } }
+        let variables = {
+          updated: { _gte: roundedOneAgo(this.selectedDateFilter) }
+        }
 
         if (this.aggregate) {
           variables.flow_group_id = this.flow.flow_group_id

--- a/src/pages/Flow/Summary-Tile.vue
+++ b/src/pages/Flow/Summary-Tile.vue
@@ -2,7 +2,7 @@
 import CardTitle from '@/components/Card-Title'
 import StackedLineChart from '@/components/Visualizations/StackedLineChart'
 import { STATE_COLORS, STATE_PAST_TENSE } from '@/utils/states'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 
 export default {
   components: {
@@ -110,7 +110,7 @@ export default {
         }
 
         if (!this.flow.archived) {
-          variables.heartbeat = oneAgo(this.selectedDateFilter)
+          variables.heartbeat = roundedOneAgo(this.selectedDateFilter)
         }
         return variables
       },

--- a/src/pages/Task/TaskRunHeartbeat-Tile.vue
+++ b/src/pages/Task/TaskRunHeartbeat-Tile.vue
@@ -1,7 +1,7 @@
 <script>
 import CardTitle from '@/components/Card-Title'
 import HeartbeatTimeline from '@/components/HeartbeatTimeline'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 import { heartbeatMixin } from '@/mixins/heartbeatMixin.js'
 
 export default {
@@ -20,7 +20,7 @@ export default {
     timestamp: {
       type: String,
       required: false,
-      default: () => oneAgo('hour')
+      default: () => roundedOneAgo('hour')
     }
   },
   data() {
@@ -35,7 +35,7 @@ export default {
       variables() {
         return {
           taskId: this.taskId,
-          timestamp: oneAgo('hour'),
+          timestamp: roundedOneAgo('hour'),
           state: this.checkedState
         }
       }

--- a/src/pages/Task/TaskRunTable-Tile.vue
+++ b/src/pages/Task/TaskRunTable-Tile.vue
@@ -1,6 +1,6 @@
 <script>
 import CardTitle from '@/components/Card-Title'
-import { oneAgo } from '@/utils/dateTime'
+import { roundedOneAgo } from '@/utils/dateTime'
 import DurationSpan from '@/components/DurationSpan'
 import { formatTime } from '@/mixins/formatTimeMixin'
 
@@ -74,7 +74,7 @@ export default {
         orderBy[`${this.sortBy}`] = this.sortDesc ? 'desc' : 'asc'
         return {
           taskId: this.taskId,
-          heartbeat: oneAgo(this.selectedDateFilter),
+          heartbeat: roundedOneAgo(this.selectedDateFilter),
           limit: this.itemsPerPage,
           offset: this.offset,
           orderBy
@@ -91,7 +91,7 @@ export default {
       variables() {
         return {
           taskId: this.taskId,
-          heartbeat: oneAgo(this.selectedDateFilter)
+          heartbeat: roundedOneAgo(this.selectedDateFilter)
         }
       },
       pollInterval: 5000,

--- a/src/utils/dateTime.js
+++ b/src/utils/dateTime.js
@@ -94,3 +94,31 @@ export const oneAgo = unitOftime => {
     .subtract(1, unitOftime)
     .format()
 }
+
+export const roundedOneAgo = unitOftime => {
+  let roundedTo
+
+  switch (unitOftime) {
+    case 'year':
+      roundedTo = 'month'
+      break
+    case 'month':
+      roundedTo = 'day'
+      break
+    case 'day':
+      roundedTo = 'hour'
+      break
+    case 'hour':
+      roundedTo = 'minute'
+      break
+    case 'minute':
+      roundedTo = 'second'
+      break
+  }
+
+  return moment
+    .utc()
+    .subtract(1, unitOftime)
+    .startOf(roundedTo)
+    .format()
+}


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds a new method, `roundedOneAgo` to our datetime utils and applies that method in place of all previous `oneAgo` references as they related to query polling. Also adds a hard `scheduled_start_time` reference (where `scheduled_start_time` is greater than or equal to 1 month ago) to dashboard timeline queries to improve the performance of that query. Overall this should reduce the number of API timeouts we see on the dashboard and flow pages, particularly when project filters are applied.

Fixes: #552 