### PR TITLE
Wrap link artifacts in router links to allow relative navigation

### DIFF
--- a/src/components/Artifacts/Artifact.vue
+++ b/src/components/Artifacts/Artifact.vue
@@ -1,13 +1,22 @@
 <script>
 /* eslint-disable vue/no-v-html */
+import ExternalLink from '@/components/ExternalLink'
 import { artifact_parser } from '@/utils/markdownParser'
 import '@/styles/atelier-sulphurpool-light.scss'
 
+const httpRegex = /^(http|https)/
+
 export default {
+  components: { ExternalLink },
   props: {
     artifact: {
       type: Object,
       required: true
+    }
+  },
+  computed: {
+    isRelativeLink() {
+      return httpRegex.test(this.artifact.data?.link)
     }
   },
   methods: {
@@ -26,9 +35,12 @@ export default {
   >
   </div>
   <div v-else-if="artifact.kind == 'link'">
-    <router-link :to="{ path: artifact.data.link }">
+    <router-link v-if="!isRelativeLink" :to="{ path: artifact.data.link }">
       {{ artifact.data.link }}
     </router-link>
+    <ExternalLink v-else :href="artifact.data.link">
+      {{ artifact.data.link }}
+    </ExternalLink>
   </div>
   <div v-else>
     {{ artifact }}

--- a/src/components/Artifacts/Artifact.vue
+++ b/src/components/Artifacts/Artifact.vue
@@ -16,7 +16,7 @@ export default {
   },
   computed: {
     isRelativeLink() {
-      return httpRegex.test(this.artifact.data?.link)
+      return !httpRegex.test(this.artifact.data?.link)
     }
   },
   methods: {
@@ -35,7 +35,7 @@ export default {
   >
   </div>
   <div v-else-if="artifact.kind == 'link'">
-    <router-link v-if="!isRelativeLink" :to="{ path: artifact.data.link }">
+    <router-link v-if="isRelativeLink" :to="{ path: artifact.data.link }">
       {{ artifact.data.link }}
     </router-link>
     <ExternalLink v-else :href="artifact.data.link">

--- a/src/components/Artifacts/Artifact.vue
+++ b/src/components/Artifacts/Artifact.vue
@@ -20,7 +20,7 @@ export default {
 
 <template>
   <div
-    v-if="artifact.kind == 'md'"
+    v-if="artifact.kind == 'md' || artifact.kind == 'markdown'"
     class="artifact md grey--text text--darken-3 mx-4"
     v-html="mdParser(artifact.data.markdown)"
   >

--- a/src/components/Artifacts/Artifact.vue
+++ b/src/components/Artifacts/Artifact.vue
@@ -20,9 +20,18 @@ export default {
 
 <template>
   <div
+    v-if="artifact.kind == 'md'"
     class="artifact md grey--text text--darken-3 mx-4"
-    v-html="mdParser(artifact.data.markdown || artifact.data.link)"
+    v-html="mdParser(artifact.data.markdown)"
   >
+  </div>
+  <div v-else-if="artifact.kind == 'link'">
+    <router-link :to="{ path: artifact.data.link }">
+      {{ artifact.data.link }}
+    </router-link>
+  </div>
+  <div v-else>
+    {{ artifact }}
   </div>
 </template>
 


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Wraps artifact links (including those generated from `StartFlowRun`) in router links to allow relative in-app navigation. This is a stop gap until we can expose a better interface for link artifacts, since the current one is designed around larger markdown-based artifacts.

Resolves: #549