### PR TITLE
make sure we're on the correct tab when mounting page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Show proper page tab on page reload - [#561](https://github.com/PrefectHQ/ui/pull/561)
 
 ## 2021-01-19
 

--- a/src/components/NavTabBar.vue
+++ b/src/components/NavTabBar.vue
@@ -35,9 +35,12 @@ export default {
       let query = {}
       if (val) {
         if (this.$route.params.id) {
-          query = { [val]: this.$route.params.id } // schematic uses this
+          query[val] = this.$route.params.id // schematic uses this
         }
-        query = { [val]: '' }
+        if (this.$route.query.version) {
+          query.version = this.$route.query.version
+        }
+        query[val] = ''
       }
       this.$router
         .replace({

--- a/src/pages/Flow/Flow.vue
+++ b/src/pages/Flow/Flow.vue
@@ -176,6 +176,7 @@ export default {
   },
   async beforeMount() {
     await this.activateFlow(this.$route.params.id)
+    this.tab = this.getTab()
   },
   methods: {
     ...mapActions('data', ['activateFlow', 'resetActiveData']),

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -123,6 +123,9 @@ export default {
       if (val === 'not-found') this.$router.push({ name: 'not-found' })
     }
   },
+  beforeMount() {
+    this.tab = this.getTab()
+  },
   methods: {
     ...mapActions('alert', ['setAlert']),
     getTab() {

--- a/src/pages/Task/Task.vue
+++ b/src/pages/Task/Task.vue
@@ -113,17 +113,7 @@ export default {
   },
   async beforeMount() {
     await this.activateTask(this.$route.params.id)
-  },
-  mounted() {
-    if (!this.$route.query || !this.$route.query.schematic) {
-      this.$router
-        .replace({
-          query: {
-            schematic: this.taskId
-          }
-        })
-        .catch(e => e)
-    }
+    this.tab = this.getTab()
   },
   methods: {
     ...mapActions('data', ['activateTask', 'resetActiveData']),

--- a/src/store/auth0/index.js
+++ b/src/store/auth0/index.js
@@ -238,7 +238,9 @@ const actions = {
     commit('isAuthenticated', isAuthenticated)
 
     if (window.location?.pathname && !getters['redirectRoute']) {
-      dispatch('setRedirectRoute', window.location.pathname)
+      const pathnameWithParams =
+        window.location.pathname + window.location.search
+      dispatch('setRedirectRoute', pathnameWithParams)
     }
 
     if (window.location?.search?.includes('invitation_id=')) {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Should fix bug reported in #486, where refreshing a page ended you back on the "overview" tab regardless of where you started (and what was highlighted as active)