### PR TITLE
Improve auth errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Improve auth error handling in access_denied circumstances and add a new error page - [#576](https://github.com/PrefectHQ/ui/pull/576)
 
 ### Bugfixes
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,16 @@ import debounce from 'lodash.debounce'
 
 const SERVER_KEY = `${process.env.VUE_APP_RELEASE_TIMESTAMP}_server_url`
 
-const fullPageRoutes = ['api', '404', 'calendar', 'not-found', 'logout']
+const fullPageRoutes = [
+  'api',
+  '404',
+  'calendar',
+  'not-found',
+  'logout',
+  'welcome'
+]
+
+const onboardRoutes = ['welcome', 'name-team', 'onboard-resources', 'accept']
 
 export default {
   metaInfo() {
@@ -93,7 +102,11 @@ export default {
       )
     },
     showNav() {
-      if (this.$route.name === 'not-found') return false
+      if (
+        this.$route.name === 'not-found' ||
+        onboardRoutes.includes(this.$route.name)
+      )
+        return false
       return (
         ((this.isCloud && this.isAuthenticated) || this.isServer) &&
         this.loadedComponents > 0

--- a/src/middleware/authNavGuard.js
+++ b/src/middleware/authNavGuard.js
@@ -31,6 +31,11 @@ const authNavGuard = async (to, from, next) => {
   // If the user isn't authenticated or authorized
   // at this point, we abort navigation
   if (!isAuthenticated() || !isAuthorized()) {
+    if (store.getters['auth/error'] == 'access_denied') {
+      return next({
+        name: 'access-denied'
+      })
+    }
     return next(false)
   }
 

--- a/src/pages/AccessDenied.vue
+++ b/src/pages/AccessDenied.vue
@@ -1,0 +1,97 @@
+<script>
+import { mapActions } from 'vuex'
+export default {
+  data() {
+    return {
+      origin: window.location.origin
+    }
+  },
+  methods: {
+    ...mapActions('auth', ['login']),
+    redirectToLogin() {
+      this.login()
+    }
+  }
+}
+</script>
+
+<template>
+  <div
+    class="access-denied"
+    :class="{
+      small: $vuetify.breakpoint.sm,
+      med: $vuetify.breakpoint.mdAndUp,
+      mobile: $vuetify.breakpoint.xs
+    }"
+  >
+    <div class="text py-16 px-8 rounded">
+      <h1>Oops!</h1>
+      <p>
+        It looks like you don't have access to this application. If you believe
+        this is an error, contact us at help@prefect.io
+      </p>
+
+      <v-btn
+        v-if="origin !== 'cloud.prefect.io'"
+        color="white"
+        class="primary--text"
+        depressed
+        href="https://cloud.prefect.io"
+      >
+        <v-icon class="mr-4">cloud</v-icon>
+        Take me to Prefect Cloud
+      </v-btn>
+
+      <v-btn
+        v-else
+        color="white"
+        class="primary--text"
+        depressed
+        @click="redirectToLogin"
+      >
+        <v-icon>arrow_back_ios</v-icon>
+        Back to login
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+i {
+  text-decoration: none;
+}
+
+.access-denied {
+  background-color: var(--v-primary-base) !important;
+  background-image: url('../assets/backgrounds/not-found.svg') !important;
+  background-position: left !important;
+  background-repeat: no-repeat !important;
+  background-size: cover !important;
+  color: #f0faff;
+  height: 100vh;
+
+  .text {
+    background-color: rgba(0, 0, 0, 0.2);
+    position: fixed;
+    top: 15%;
+  }
+
+  &.small {
+    .text {
+      left: 25%;
+    }
+  }
+
+  &.med {
+    .text {
+      left: 20%;
+    }
+  }
+
+  &.mobile {
+    .text {
+      left: 5%;
+    }
+  }
+}
+</style>

--- a/src/router.js
+++ b/src/router.js
@@ -339,6 +339,12 @@ export const routes = [
     beforeEnter: multiguard([authNavGuard, tenantNavGuard])
   },
   {
+    name: 'access-denied',
+    path: '/access-denied',
+    component: () =>
+      import(/* webpackChunkName: "access-denied" */ '@/pages/AccessDenied.vue')
+  },
+  {
     path: '*',
     redirect: '404'
   }

--- a/src/store/auth/index.js
+++ b/src/store/auth/index.js
@@ -317,6 +317,8 @@ const actions = {
     return getters['isAuthenticated']
   },
   async authorize({ commit, getters, dispatch }) {
+    if (!getters['isAuthenticated']) return
+
     commit('isAuthorizingUser', true)
 
     const user = await authClient.getUser()

--- a/src/store/auth/index.js
+++ b/src/store/auth/index.js
@@ -275,7 +275,10 @@ const actions = {
     // const errorDescription = urlParams.get('error_description') // We don't need to capture this at the moment
 
     if (window.location?.pathname && !getters['redirectRoute']) {
-      dispatch('setRedirectRoute', window.location.pathname)
+      dispatch(
+        'setRedirectRoute',
+        window.location.pathname + window.location.search
+      )
     }
 
     if (invitationId) {

--- a/tests/unit/store/auth.spec.js
+++ b/tests/unit/store/auth.spec.js
@@ -686,15 +686,21 @@ describe('auth Vuex Module', () => {
         isAuthenticated.mockReturnValueOnce(false)
 
         const redirectRoute = '/path/to/some/place',
-          otherRedirectRoute = '/path/to/some/other/place'
+          otherRedirectRoute = '/path/to/some/other/place',
+          searchParams = '?some_query=123'
         await store.dispatch('setRedirectRoute', redirectRoute)
         expect(store.getters['redirectRoute']).toBe(redirectRoute)
 
         delete window.location
-        window.location = { pathname: otherRedirectRoute, search: '' }
+        window.location = {
+          pathname: otherRedirectRoute,
+          search: searchParams
+        }
 
         await store.dispatch('authenticate')
-        expect(store.getters['redirectRoute']).not.toBe(otherRedirectRoute)
+        expect(store.getters['redirectRoute']).not.toBe(
+          otherRedirectRoute + searchParams
+        )
       })
     })
 

--- a/tests/unit/store/auth.spec.js
+++ b/tests/unit/store/auth.spec.js
@@ -932,7 +932,7 @@ describe('auth Vuex Module', () => {
       })
     })
 
-    describe('updateAuthentication  with query params', () => {
+    describe('authentication flow with query params', () => {
       let store
 
       beforeEach(() => {

--- a/tests/unit/store/auth.spec.js
+++ b/tests/unit/store/auth.spec.js
@@ -98,7 +98,7 @@ describe('auth Vuex Module', () => {
     it('should be initialized properly without tokens in localStorage ', () => {
       const state = auth.state
 
-      expect(Object.keys(state).length).toBe(15)
+      expect(Object.keys(state).length).toBe(16)
 
       expect(state.user).toBe(null)
       expect(state.authorizationToken).toBe(null)

--- a/tests/unit/store/auth.spec.js
+++ b/tests/unit/store/auth.spec.js
@@ -932,7 +932,7 @@ describe('auth Vuex Module', () => {
       })
     })
 
-    describe('a user comes from an email invite link', () => {
+    describe('updateAuthentication  with query params', () => {
       let store
 
       beforeEach(() => {
@@ -942,14 +942,37 @@ describe('auth Vuex Module', () => {
           actions: auth.actions,
           mutations: auth.mutations
         })
+
+        delete window.location
+
         isAuthenticated.mockReturnValue(false)
       })
-      delete window.location
-      window.location = { search: '?invitation_id=xyz' }
 
-      it('stores the invitation id in local storage', async () => {
-        await store.dispatch('authenticate')
-        expect(sessionStorage.getItem('invitationId')).toBe('xyz')
+      describe('a user comes from an email invite link', () => {
+        it('stores the invitation id in local storage', async () => {
+          window.location = { search: '?invitation_id=xyz' }
+
+          await store.dispatch('authenticate')
+          expect(sessionStorage.getItem('invitationId')).toBe('xyz')
+        })
+      })
+
+      describe('the url contains a partner source', () => {
+        it('stores the partner source in session storage', async () => {
+          window.location = { search: '?partner_source=prefect' }
+
+          await store.dispatch('authenticate')
+          expect(sessionStorage.getItem('partnerSource')).toBe('prefect')
+        })
+      })
+
+      describe('the url contains an authentication error', () => {
+        it('stores the error and aborts the authentication flow', async () => {
+          window.location = { search: '?error=access_denied' }
+
+          await store.dispatch('authenticate')
+          expect(store.getters['error']).toBe('access_denied')
+        })
       })
     })
   })

--- a/tests/unit/store/auth.spec.js
+++ b/tests/unit/store/auth.spec.js
@@ -58,6 +58,7 @@ describe('auth Vuex Module', () => {
     return {
       authorizationToken: MOCK_AUTHORIZATION_TOKEN,
       authorizationTokenExpiry: new Date().getTime() + 10000,
+      error: null,
       idToken: MOCK_ID_TOKEN,
       idTokenExpiry: jwt_decode(MOCK_ID_TOKEN).exp * 1000,
       isAuthenticated: true,
@@ -80,6 +81,7 @@ describe('auth Vuex Module', () => {
     return {
       authorizationToken: null,
       authorizationTokenExpiry: null,
+      error: null,
       idToken: null,
       idTokenExpiry: null,
       isAuthenticated: false,
@@ -134,6 +136,21 @@ describe('auth Vuex Module', () => {
 
     it('should return the user', () => {
       expect(store.getters.user).toBe(store.state.user)
+    })
+
+    it('should return the error property', () => {
+      const errorState = loggedOutState()
+
+      errorState.error = 'access_denied'
+
+      store = new Vuex.Store({
+        state: errorState,
+        getters: auth.getters,
+        actions: auth.actions,
+        mutations: auth.mutations
+      })
+
+      expect(store.getters.error).toBe(store.state.error)
     })
 
     it('should return the idToken', () => {
@@ -226,6 +243,12 @@ describe('auth Vuex Module', () => {
         const idToken = loggedInState().idToken
         store.commit('idToken', idToken)
         expect(store.getters['idToken']).toBe(idToken)
+      })
+
+      it('should set the error property', () => {
+        const error = 'access_denied'
+        store.commit('error', error)
+        expect(store.getters['error']).toBe(error)
       })
 
       it('should set isAuthenticated', () => {

--- a/tests/unit/store/tenant.spec.js
+++ b/tests/unit/store/tenant.spec.js
@@ -362,7 +362,7 @@ describe('tenant Vuex Module', () => {
       let store
 
       beforeEach(() => {
-        tenant.actions['auth0/updateAuthorization'] = jest.fn
+        tenant.actions['auth/updateAuthorization'] = jest.fn()
         tenant.actions['license/getLicense'] = jest.fn()
         store = new Vuex.Store({
           state: initialTenantState(),


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- Improves client application error handling related to the okta flow; users without access to the identity application will be redirected to a new access-denied page and (more importantly) the auth flow will not continue in a loop
- Hides the navbar during the onboarding screens
- Adds query param handling to the auth store (parity with the previous auth0 store) to make sure we can handle tab navigation