### PR TITLE
Use role_detail instead of role

### DIFF
--- a/src/graphql/Notifications/membership-invitation.gql
+++ b/src/graphql/Notifications/membership-invitation.gql
@@ -2,6 +2,7 @@ query MembershipInvitation($id: uuid!) {
   membership_invitation_by_pk(id: $id) {
     id
     role_detail {
+      id
       name
     }
     email

--- a/src/graphql/Notifications/membership-invitation.gql
+++ b/src/graphql/Notifications/membership-invitation.gql
@@ -1,7 +1,9 @@
 query MembershipInvitation($id: uuid!) {
   membership_invitation_by_pk(id: $id) {
     id
-    role
+    role_detail {
+      name
+    }
     email
     created
     tenant {

--- a/src/graphql/Tenant/membership-invitation.gql
+++ b/src/graphql/Tenant/membership-invitation.gql
@@ -4,6 +4,7 @@ query Memberships($id: uuid!) {
     created
     email
     role_detail {
+      id
       name
     }
     tenant {

--- a/src/graphql/Tenant/membership-invitation.gql
+++ b/src/graphql/Tenant/membership-invitation.gql
@@ -3,7 +3,9 @@ query Memberships($id: uuid!) {
     id
     created
     email
-    role
+    role_detail {
+      name
+    }
     tenant {
       id
       name

--- a/src/graphql/Tenant/membership.gql
+++ b/src/graphql/Tenant/membership.gql
@@ -2,6 +2,7 @@ query Membership($membershipId: uuid!) {
   membership(where: { id: { _eq: $membershipId } }) {
     id
     role_detail {
+      id
       name
     }
     tenant {

--- a/src/graphql/Tenant/membership.gql
+++ b/src/graphql/Tenant/membership.gql
@@ -1,7 +1,9 @@
 query Membership($membershipId: uuid!) {
   membership(where: { id: { _eq: $membershipId } }) {
     id
-    role
+    role_detail {
+      name
+    }
     tenant {
       id
       name

--- a/src/graphql/Tenant/pending-invitations-by-email.gql
+++ b/src/graphql/Tenant/pending-invitations-by-email.gql
@@ -4,6 +4,7 @@ query PendingInvitations($email: String!) {
   ) {
     id
     role_detail {
+      id
       name
     }
     email

--- a/src/graphql/Tenant/pending-invitations-by-email.gql
+++ b/src/graphql/Tenant/pending-invitations-by-email.gql
@@ -3,7 +3,9 @@ query PendingInvitations($email: String!) {
     where: { email: { _eq: $email } }
   ) {
     id
-    role
+    role_detail {
+      name
+    }
     email
     created
     tenant {

--- a/src/graphql/Tenant/pending-invitations.gql
+++ b/src/graphql/Tenant/pending-invitations.gql
@@ -4,6 +4,7 @@ query PendingInvitations {
     created
     email
     role_detail {
+      id
       name
     }
     tenant {

--- a/src/graphql/Tenant/pending-invitations.gql
+++ b/src/graphql/Tenant/pending-invitations.gql
@@ -3,7 +3,9 @@ query PendingInvitations {
     id
     created
     email
-    role
+    role_detail {
+      name
+    }
     tenant {
       id
     }

--- a/src/graphql/Tenant/tenant-users.gql
+++ b/src/graphql/Tenant/tenant-users.gql
@@ -7,8 +7,11 @@ query TenantUsers {
     last_name
     memberships {
       id
-      role
       tenant_id
+      role_detail {
+        id
+        name
+      }
     }
   }
 }

--- a/src/graphql/User/user.gql
+++ b/src/graphql/User/user.gql
@@ -9,11 +9,13 @@ query User {
     last_name
     memberships {
       id
-      role
       tenant {
         id
         name
         slug
+      }
+      role_detail {
+        name
       }
     }
   }

--- a/src/graphql/User/user.gql
+++ b/src/graphql/User/user.gql
@@ -15,6 +15,7 @@ query User {
         slug
       }
       role_detail {
+        id
         name
       }
     }

--- a/src/pages/TeamSettings/Members/Invitations-Table.vue
+++ b/src/pages/TeamSettings/Members/Invitations-Table.vue
@@ -131,7 +131,7 @@ export default {
             return {
               email: invitation.email,
               membershipInvitationId: invitation.id,
-              role: invitation.role,
+              role: invitation.role_detail.name,
               pending: true,
               created: invitation.created
             }

--- a/src/pages/TeamSettings/Members/Members-Table.vue
+++ b/src/pages/TeamSettings/Members/Members-Table.vue
@@ -197,7 +197,7 @@ export default {
               firstName: user.first_name,
               lastName: user.last_name,
               userId: user.id,
-              role: membership.role,
+              role: membership.role_detail.name,
               membershipId: membership.id
             }
           })

--- a/src/store/tenant/index.js
+++ b/src/store/tenant/index.js
@@ -160,7 +160,7 @@ const actions = {
 
         tenant.role = rootGetters['user/memberships'].find(
           membership => membership.tenant.id == tenant.id
-        )?.role_detail.name
+        )?.role_detail?.name
       } else {
         tenant.role = 'TENANT_ADMIN'
       }

--- a/src/store/tenant/index.js
+++ b/src/store/tenant/index.js
@@ -160,7 +160,7 @@ const actions = {
 
         tenant.role = rootGetters['user/memberships'].find(
           membership => membership.tenant.id == tenant.id
-        )?.role
+        )?.role_detail.name
       } else {
         tenant.role = 'TENANT_ADMIN'
       }

--- a/tests/unit/store/tenant.spec.js
+++ b/tests/unit/store/tenant.spec.js
@@ -370,9 +370,15 @@ describe('tenant Vuex Module', () => {
             ...tenant.getters,
             'api/isCloud': () => true,
             'user/memberships': () => [
-              { tenant: { id: '12345' }, role: 'USER' },
-              { tenant: { id: '45678' }, role: 'TENANT_ADMIN' },
-              { tenant: { id: '9101112' }, role: 'READ_ONLY_USER' }
+              { tenant: { id: '12345' }, role_detail: { name: 'USER' } },
+              {
+                tenant: { id: '45678' },
+                role_detail: { name: 'TENANT_ADMIN' }
+              },
+              {
+                tenant: { id: '9101112' },
+                role_detail: { name: 'READ_ONLY_USER' }
+              }
             ]
           },
           mutations: tenant.mutations,
@@ -400,6 +406,7 @@ describe('tenant Vuex Module', () => {
         ]
         prefectTenants.mockReturnValueOnce(tenantsArray)
         await store.dispatch('setCurrentTenant', 'team1')
+
         expect(store.getters.role).toEqual('READ_ONLY_USER')
       })
     })


### PR DESCRIPTION
The `role` field in graphql is deprecated. This PR replaces calls to that field with a `role_detail` relationship to get additional information (in this case, the role name).

(Note: once released, we will remove the `role` field entirely as the UI is its only consumer and rename the `role_detail` relationship back to `role`)


PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
