### PR TITLE
don't show tutorial banner on server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Update wording on tutorial banner for server users - [#592](https://github.com/PrefectHQ/ui/pull/592)
 
 ### Bugfixes
 

--- a/src/components/TutorialBanner.vue
+++ b/src/components/TutorialBanner.vue
@@ -17,7 +17,9 @@ export default {
   },
   computed: {
     ...mapGetters('data', ['flows']),
+    ...mapGetters('api', ['isCloud']),
     showBanner() {
+      if (!this.isCloud) return false
       let show = this.flows?.length === 0
       if (!this.dismissed && this.pageScroll) {
         show = !this.pageScroll

--- a/src/components/TutorialBanner.vue
+++ b/src/components/TutorialBanner.vue
@@ -19,14 +19,13 @@ export default {
     ...mapGetters('data', ['flows']),
     ...mapGetters('api', ['isCloud']),
     showBanner() {
-      return true
-      // let show = this.flows?.length === 0
-      // if (!this.dismissed && this.pageScroll) {
-      //   show = !this.pageScroll
-      // } else if (this.dismissed || this.$vuetify.breakpoint.smAndDown) {
-      //   show = false
-      // }
-      // return show
+      let show = this.flows?.length === 0
+      if (!this.dismissed && this.pageScroll) {
+        show = !this.pageScroll
+      } else if (this.dismissed || this.$vuetify.breakpoint.smAndDown) {
+        show = false
+      }
+      return show
     }
   }
 }

--- a/src/components/TutorialBanner.vue
+++ b/src/components/TutorialBanner.vue
@@ -19,14 +19,14 @@ export default {
     ...mapGetters('data', ['flows']),
     ...mapGetters('api', ['isCloud']),
     showBanner() {
-      if (!this.isCloud) return false
-      let show = this.flows?.length === 0
-      if (!this.dismissed && this.pageScroll) {
-        show = !this.pageScroll
-      } else if (this.dismissed || this.$vuetify.breakpoint.smAndDown) {
-        show = false
-      }
-      return show
+      return true
+      // let show = this.flows?.length === 0
+      // if (!this.dismissed && this.pageScroll) {
+      //   show = !this.pageScroll
+      // } else if (this.dismissed || this.$vuetify.breakpoint.smAndDown) {
+      //   show = false
+      // }
+      // return show
     }
   }
 }
@@ -42,13 +42,19 @@ export default {
           </v-icon>
         </v-avatar>
         <div class="ml-4">
-          Pst! It looks like you don't have any flows yet; check out the
-          <router-link :to="{ name: 'tutorial' }"> tutorials</router-link> for
-          walkthroughs on writing and registering flows with Prefect and the
-          <ExternalLink href="https://docs.prefect.io/"
-            >documentation</ExternalLink
+          Pst! It looks like you don't have any flows yet;
+          <span v-if="isCloud"
+            >check out the
+            <router-link :to="{ name: 'tutorial' }"> tutorials</router-link> for
+            walkthroughs on writing and registering flows with Prefect and the
+            for more in-depth looks at the Prefect APIs</span
+          ><span v-else>
+            check out our
+            <ExternalLink href="https://docs.prefect.io/"
+              >documentation</ExternalLink
+            >
+            for help on getting started.</span
           >
-          for more in-depth looks at the Prefect APIs
         </div>
         <v-btn
           class="ml-auto"


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
When I opened a fresh version of server the banner popped up telling me about our tutorials.  Those tutorials are cloud centric and potentially confusing for server users.  This PR updates the banner wording for server to go to the docs instead of cloud tutorials. 