### PR TITLE
Show label warning on Server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- Check for missing or mismatched labels on Server - []()
+- Check for missing or mismatched labels on Server - [#593](https://github.com/PrefectHQ/ui/pull/593)
 
 ### Bugfixes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Check for missing or mismatched labels on Server - []()
 
 ### Bugfixes
 

--- a/src/components/LabelWarning.vue
+++ b/src/components/LabelWarning.vue
@@ -32,8 +32,7 @@ export default {
   },
   computed: {
     ...mapGetters('tenant', ['tenant']),
-    ...mapGetters('agent', ['agents']),
-    ...mapGetters('api', ['isCloud']),
+    ...mapGetters('agent', ['agents'])
     agentOrLabel() {
       if (!this.agents || !this.agents.length) return 'Agent Problem'
       if (!this.labelsAlign) return 'Label Problem'
@@ -110,7 +109,7 @@ export default {
 
 <template>
   <v-menu
-    v-if="!labelsAlign && isCloud"
+    v-if="!labelsAlign"
     :close-on-content-click="false"
     offset-y
     open-on-hover

--- a/src/components/LabelWarning.vue
+++ b/src/components/LabelWarning.vue
@@ -32,7 +32,7 @@ export default {
   },
   computed: {
     ...mapGetters('tenant', ['tenant']),
-    ...mapGetters('agent', ['agents'])
+    ...mapGetters('agent', ['agents']),
     agentOrLabel() {
       if (!this.agents || !this.agents.length) return 'Agent Problem'
       if (!this.labelsAlign) return 'Label Problem'


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- When we added the label warning, agent labels weren't yet in server.  Now they are so we should enable this component in server too.  Should help reduce the questions about labels in the community slack too. 