### PR TITLE
Dont specify labels on run config - results in bad config schemas

### DIFF
--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -127,7 +127,7 @@ export default {
       acc[param.name] = param.default
       return acc
     }, {})
-    this.runConfig = { ...this.flow.run_config, labels: this.labels }
+    this.runConfig = { ...this.flow.run_config }
 
     window.addEventListener('scroll', this.handleScroll)
   },


### PR DESCRIPTION
This PR fixes an issue with the Run page - anytime you use that page and don't edit the run config, we were creating a bad run config schema that couldn't be parsed by agents, resulting in flow run failures.