### PR TITLE
make content a sibling of background so it'll scroll

### DIFF
--- a/src/pages/Onboard/NameTeam.vue
+++ b/src/pages/Onboard/NameTeam.vue
@@ -435,7 +435,7 @@ export default {
               v-show="selectedOption == 'Other'"
               dark
               autofocus
-              placeholder="Where did you hear about us?"
+              placeholder="Newsletter, advertisement, etc..."
               @input="setExtraInfo"
             ></v-text-field>
           </v-col>

--- a/src/pages/Onboard/NameTeam.vue
+++ b/src/pages/Onboard/NameTeam.vue
@@ -553,19 +553,11 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-.h-80 {
-  min-height: calc(80vh - 64px) !important;
-}
-
 .transition-height {
   transition: max-height 500ms ease;
 }
 
 .name-team-input {
   max-width: 700px;
-}
-
-.w-100 {
-  width: 100vw;
 }
 </style>

--- a/src/pages/Onboard/Onboard-Page.vue
+++ b/src/pages/Onboard/Onboard-Page.vue
@@ -12,8 +12,6 @@ export default {
       let route = this.$route.name
       return {
         'overflow-y-hidden': this.$vuetify.breakpoint.mdAndUp,
-        'h-100': route == 'welcome',
-        'mh-100': this.nameTeamOrAcceptRoute,
         'bg-blue': route == 'welcome',
         'bg-grey': this.nameTeamOrAcceptRoute
       }
@@ -107,7 +105,7 @@ export default {
 
 <template>
   <v-container
-    class="ma-0 pa-0 position-relative test-bg"
+    class="ma-0 pa-0 position-relative test-bg mh-100"
     :class="containerClass"
     fluid
   >
@@ -181,10 +179,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-.h-100 {
-  height: 100vh !important;
-}
-
 .mh-100 {
   min-height: 100vh !important;
 }

--- a/src/pages/Onboard/Onboard-Page.vue
+++ b/src/pages/Onboard/Onboard-Page.vue
@@ -173,10 +173,9 @@ export default {
     </transition-group>
 
     <v-container class="position-absolute onboard-content pa-0" fluid>
-      <transition name="fade" mode="out-in">
-        <router-view class="router-view" />
-      </transition>
+      <transition name="fade" mode="out-in"> </transition>
     </v-container>
+    <router-view class="router-view" style="z-index: 3;" />
   </v-container>
 </template>
 
@@ -201,7 +200,6 @@ export default {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  z-index: 3;
 }
 
 .o-slash {

--- a/src/pages/Onboard/Onboard-Page.vue
+++ b/src/pages/Onboard/Onboard-Page.vue
@@ -12,6 +12,8 @@ export default {
       let route = this.$route.name
       return {
         'overflow-y-hidden': this.$vuetify.breakpoint.mdAndUp,
+        'h-100': route == 'welcome',
+        'mh-100': this.nameTeamOrAcceptRoute,
         'bg-blue': route == 'welcome',
         'bg-grey': this.nameTeamOrAcceptRoute
       }
@@ -105,7 +107,7 @@ export default {
 
 <template>
   <v-container
-    class="ma-0 pa-0 position-relative h-100 test-bg"
+    class="ma-0 pa-0 position-relative test-bg"
     :class="containerClass"
     fluid
   >
@@ -172,15 +174,18 @@ export default {
       </div>
     </transition-group>
 
-    <v-container class="position-absolute onboard-content pa-0" fluid>
-      <transition name="fade" mode="out-in"> </transition>
-    </v-container>
-    <router-view class="router-view" style="z-index: 3;" />
+    <transition name="fade" mode="out-in"
+      ><router-view class="router-view" style="z-index: 3;" />
+    </transition>
   </v-container>
 </template>
 
 <style lang="scss" scoped>
 .h-100 {
+  height: 100vh !important;
+}
+
+.mh-100 {
   min-height: 100vh !important;
 }
 
@@ -194,12 +199,6 @@ export default {
 
 .bg-grey {
   background-image: linear-gradient(105deg, #2f383f, #647489) !important;
-}
-
-.onboard-content {
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
 }
 
 .o-slash {

--- a/src/pages/Onboard/Onboard-Page.vue
+++ b/src/pages/Onboard/Onboard-Page.vue
@@ -206,7 +206,6 @@ export default {
   backface-visibility: hidden;
   position: absolute;
   transition: all 250ms;
-  z-index: 2;
 
   &.slash-full {
     height: 100vh !important;

--- a/src/pages/Onboard/Resources.vue
+++ b/src/pages/Onboard/Resources.vue
@@ -36,7 +36,7 @@ export default {
   <v-container class="pa-0 h-100 fill-height" style="max-width: 2560px;" fluid>
     <v-row v-if="$vuetify.breakpoint.mdAndUp" style="z-index: 3;">
       <v-slide-x-transition>
-        <v-col v-if="showResources" cols="12" md="5" class="pl-0">
+        <v-col v-if="showResources" cols="12" md="5">
           <div
             class="d-flex align-center justify-center white--text fill-height"
             style="width: 100%;"
@@ -146,7 +146,7 @@ export default {
                 height="100%"
                 class="text-center gradient-background orange--gradient d-flex align-center justify-center "
               >
-                <div class="d-flex flex-column">
+                <div class="d-flex flex-column" style="z-index: 3;">
                   <div class="mb-8">
                     <img
                       class="photo mx-auto"
@@ -182,7 +182,10 @@ export default {
                 height="100%"
                 class="text-center gradient-background grey--gradient d-flex align-center justify-center"
               >
-                <div class="d-flex flex-column align white--text">
+                <div
+                  class="d-flex flex-column align white--text"
+                  style="z-index: 3;"
+                >
                   <div class="mb-8">
                     <img
                       class="photo mx-auto"
@@ -225,6 +228,7 @@ export default {
             class="mx-auto"
             color="primary"
             x-large
+            style="z-index: 3;"
           >
             To the dashboard!
             <v-icon right>fas fa-rocket</v-icon>

--- a/src/pages/Onboard/Resources.vue
+++ b/src/pages/Onboard/Resources.vue
@@ -34,7 +34,7 @@ export default {
 
 <template>
   <v-container class="pa-0 h-100 fill-height" style="max-width: 2560px;" fluid>
-    <v-row v-if="$vuetify.breakpoint.mdAndUp">
+    <v-row v-if="$vuetify.breakpoint.mdAndUp" style="z-index: 3;">
       <v-slide-x-transition>
         <v-col v-if="showResources" cols="12" md="5" class="pl-0">
           <div
@@ -146,7 +146,7 @@ export default {
                 height="100%"
                 class="text-center gradient-background orange--gradient d-flex align-center justify-center "
               >
-                <div class="d-flex flex-column z-1">
+                <div class="d-flex flex-column">
                   <div class="mb-8">
                     <img
                       class="photo mx-auto"
@@ -182,7 +182,7 @@ export default {
                 height="100%"
                 class="text-center gradient-background grey--gradient d-flex align-center justify-center"
               >
-                <div class="d-flex flex-column align white--text z-1">
+                <div class="d-flex flex-column align white--text">
                   <div class="mb-8">
                     <img
                       class="photo mx-auto"
@@ -241,7 +241,6 @@ export default {
   left: 50%;
   position: absolute;
   transform: translate(-50%, -50%);
-  z-index: 2;
 }
 
 .dashboard-button-row-small {
@@ -255,11 +254,6 @@ export default {
   position: absolute;
   top: 25px;
   transform: translate(-50%);
-  z-index: 2;
-}
-
-.z-1 {
-  z-index: 1 !important;
 }
 
 .gradient-background {

--- a/src/pages/Onboard/Welcome.vue
+++ b/src/pages/Onboard/Welcome.vue
@@ -20,7 +20,7 @@ export default {
 </script>
 
 <template>
-  <v-container class="text-center fill-height pa-0" fluid>
+  <v-container class="text-center pa-0" fluid>
     <v-slide-x-transition>
       <div v-if="welcome" class="grey--text text--lighten-5 welcome-text">
         <div class="display-1">
@@ -38,10 +38,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-.fill-height {
-  height: 100vh !important;
-}
-
 .welcome-text {
   left: 50%;
   max-width: 700px;

--- a/src/pages/Onboard/Welcome.vue
+++ b/src/pages/Onboard/Welcome.vue
@@ -49,7 +49,7 @@ export default {
   top: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
-  z-index: 1;
+  z-index: 3;
 }
 
 .logo {


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes an issue making some content get pushed offscreen for small screen heights in the onboarding pages.  Caused by the additional content added to the name team page in #615 