### PR TITLE
Allow cookies to be sent by BatchHttpLink

### DIFF
--- a/src/vue-apollo.js
+++ b/src/vue-apollo.js
@@ -38,7 +38,8 @@ let errors = 0,
 const batchLink = new BatchHttpLink({
   batchMax: 20,
   batchInterval: 200,
-  uri: () => store.getters['api/url']
+  uri: () => store.getters['api/url'],
+  credentials: 'include'
 })
 
 const backendMiddleware = new ApolloLink((operation, forward) => {


### PR DESCRIPTION
Add credentials: 'include' option to BatchHttpLink client, in order to allow it to send cookies if settings are met.

This will allow integration of prefect with in-house authentication / authorization services, without relying on a private full fork of prefect UI code base.
