### PR TITLE
clean up agents with NaN secondsSinceLastQuery

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Cleans up agents with no last query time = [#646](https://github.com/PrefectHQ/ui/pull/646)
 
 ## 2021-03-02
 

--- a/src/components/Agents/Agents.vue
+++ b/src/components/Agents/Agents.vue
@@ -114,9 +114,11 @@ export default {
       try {
         this.clearingAgents = true
         const unhealthyAgents = this.agents.filter(
-          agent => agent.secondsSinceLastQuery > 60 * this.unhealthyThreshold
+          agent =>
+            agent.secondsSinceLastQuery > 60 * this.unhealthyThreshold ||
+            isNaN(agent.secondsSinceLastQuery)
         )
-        if (!unhealthyAgents) {
+        if (unhealthyAgents.length === 0) {
           LogRocket.captureMessage('Clean Up button open but no agents found')
           this.setAlert({
             alertShow: true,


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes #642 where certain agents (k8s) were returning a `secondsSinceLastQuery` of `NaN` and therefore not getting caught by the existing check for unhealthy agents. 