### PR TITLE
Cancel late

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ### Bugfixes
 
+- Fix the clear button on the dashboard so that it clears scheduled runs - []()
 - Fix indefinite task run duration when using mapped cases - [#650](https://github.com/PrefectHQ/ui/pull/650)
 
 ## 2021-03-09

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- Fix the clear button on the dashboard so that it clears scheduled runs - []()
+- Fix the clear button on the dashboard so that it clears scheduled runs - [#653](https://github.com/PrefectHQ/ui/pull/653)
 - Fix indefinite task run duration when using mapped cases - [#650](https://github.com/PrefectHQ/ui/pull/650)
 
 ## 2021-03-09

--- a/src/mixins/cancelLateRunsMixin.js
+++ b/src/mixins/cancelLateRunsMixin.js
@@ -29,7 +29,7 @@ export const cancelLateRunsMixin = {
     IdCheck() {
       return this.lateRuns?.map(run => {
         if (run.flow?.is_schedule_active) {
-          this.ids.push(run.flow?.id)
+          this.scheduleIds.push(run.flow?.id)
         } else {
           this.individualRuns.push(run)
         }
@@ -48,7 +48,7 @@ export const cancelLateRunsMixin = {
         this.showClearLateRunsDialog = false
         this.isClearingLateRuns = true
         if (this.scheduleIds.length > 1) {
-          const uniqueIds = [...new Set(this.ids)]
+          const uniqueIds = [...new Set(this.scheduleIds)]
           const clearMutation = uniqueIds.map(
             (id, ind) => `
             set_schedule_inactive${ind}: set_schedule_inactive(input: { flow_id: "${id}" }) {

--- a/src/mixins/cancelLateRunsMixin.js
+++ b/src/mixins/cancelLateRunsMixin.js
@@ -9,8 +9,7 @@ export const cancelLateRunsMixin = {
       isClearingLateRuns: false,
       showClearLateRunsDialog: false,
       individualRuns: [],
-      scheduleIds: [],
-      ids: []
+      scheduledRunIds: []
     }
   },
   watch: {
@@ -29,7 +28,7 @@ export const cancelLateRunsMixin = {
     IdCheck() {
       return this.lateRuns?.map(run => {
         if (run.flow?.is_schedule_active) {
-          this.scheduleIds.push(run.flow?.id)
+          this.scheduledRunIds.push(run.flow?.id)
         } else {
           this.individualRuns.push(run)
         }
@@ -47,8 +46,8 @@ export const cancelLateRunsMixin = {
       try {
         this.showClearLateRunsDialog = false
         this.isClearingLateRuns = true
-        if (this.scheduleIds.length > 1) {
-          const uniqueIds = [...new Set(this.scheduleIds)]
+        if (this.scheduledRunIds.length > 1) {
+          const uniqueIds = [...new Set(this.scheduledRunIds)]
           const clearMutation = uniqueIds.map(
             (id, ind) => `
             set_schedule_inactive${ind}: set_schedule_inactive(input: { flow_id: "${id}" }) {

--- a/src/pages/Dashboard/UpcomingRuns-Tile.vue
+++ b/src/pages/Dashboard/UpcomingRuns-Tile.vue
@@ -427,7 +427,7 @@ export default {
               Are you sure you want to clear all late runs?
             </v-card-title>
 
-            <v-card-text v-if="scheduleIds.length > 1">
+            <v-card-text v-if="scheduledRunIds.length > 1">
               This will toggle the schedule for all flows with late runs. If you
               did not set a
               <ExternalLink


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- The UI was missing runs from a schedule when the clear button was pressed because of a mis-match between variable names.  This PR addresses the mis-match. 