### PR TITLE
Flow group created by 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ### Bugfixes
 
+- Fix the blank "Created by" column in the Flow Groups - [#657](https://github.com/PrefectHQ/ui/pull/657)
 - Fix the clear button on the dashboard so that it clears scheduled runs - [#653](https://github.com/PrefectHQ/ui/pull/653)
 - Fix indefinite task run duration when using mapped cases - [#650](https://github.com/PrefectHQ/ui/pull/650)
 

--- a/src/pages/TeamSettings/FlowGroups.vue
+++ b/src/pages/TeamSettings/FlowGroups.vue
@@ -85,6 +85,8 @@ export default {
   },
   computed: {
     ...mapGetters('tenant', ['tenant']),
+    ...mapGetters('api', ['isCloud']),
+
     deleteFvgMutation() {
       if (!this.versionGroupFlows) return {}
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
In the Flow Groups, the `created by` column was blank due to `isCloud` being undefined. This adds `...mapGetters('api', ['isCloud'])` 
