### PR TITLE
License creation/slug error 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix a bug where a license would get created even though there are validation errors present - [#672](https://github.com/PrefectHQ/ui/pull/672)
 
 ## 2021-03-15a
 

--- a/src/pages/Onboard/NameTeam.vue
+++ b/src/pages/Onboard/NameTeam.vue
@@ -125,16 +125,16 @@ export default {
       return
     },
     async updateTenant() {
+      // Async tenant checks
+      await this.checkNameAsync()
+      await this.checkSlugAsync()
+
       if (this.nameErrors.length > 0 || this.slugErrors.length > 0) {
         return
       }
 
       this.updateServerError = false
       this.loading++
-
-      // Async tenant checks
-      await this.checkNameAsync()
-      await this.checkSlugAsync()
 
       if (
         this.tenantChanges.slug == this.tenant.slug &&

--- a/src/pages/Onboard/NameTeam.vue
+++ b/src/pages/Onboard/NameTeam.vue
@@ -158,9 +158,7 @@ export default {
           await this.getTenants()
         } catch (e) {
           if (e.message.includes('Uniqueness violation')) {
-            this.slugErrors = [
-              'Sorry, that URL slug is already in use. Please try another URL Slug.'
-            ]
+            this.slugErrors = ['Sorry, that slug is already in use.']
           } else {
             this.updateServerError = true
           }

--- a/src/pages/Onboard/NameTeam.vue
+++ b/src/pages/Onboard/NameTeam.vue
@@ -80,7 +80,6 @@ export default {
     ...mapActions('user', ['getUser']),
     async createLicense() {
       this.loading++
-
       try {
         // Create the stripe customer (necessary for creating a self serve license)
         await this.$apollo.mutate({
@@ -93,7 +92,6 @@ export default {
             }
           }
         })
-
         // Create the self serve license
         // await this.$apollo.mutate({
         //   mutation: require('@/graphql/License/create-self-serve-license.gql'),
@@ -159,11 +157,20 @@ export default {
 
           await this.getTenants()
         } catch (e) {
-          this.updateServerError = true
+          if (e.message.includes('Uniqueness violation')) {
+            this.slugErrors = [
+              'Sorry, that URL slug is already in use. Please try another URL Slug.'
+            ]
+          } else {
+            this.updateServerError = true
+          }
         }
       }
 
       this.loading--
+      if (this.slugErrors.length > 0) {
+        return
+      }
       await this.createLicense()
       if (!this.updateServerError) this.goToResources()
     },


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This aims to not create a license when the slug or name validation fails and displays the error message if the slug fails one of the validation checks