### PR TITLE
More flow run page improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,13 @@
 ### Features and Improvements
 
 - Add the "Running" state to the state filter - [#675](https://github.com/PrefectHQ/ui/pull/675)
+- Flow run page performance improvements (part 1) and shared service worker for token refresh - [#679](https://github.com/PrefectHQ/ui/pull/679)
+- Flow run page performance improvements (part 2) - [#688](https://github.com/PrefectHQ/ui/pull/688)
 
 ### Bugfixes
 
 - None
+
 ## 2021-03-16
 
 ### Bugfixes

--- a/src/main.js
+++ b/src/main.js
@@ -362,14 +362,7 @@ const handleVisibilityChange = () => {
   )
   const authenticationExpiration = new Date(store.getters['auth/idTokenExpiry'])
 
-  // eslint-disable-next-line no-console
-  console.log(
-    'Handling visibility change',
-    document[hidden],
-    now >= authorizationExpiration,
-    now < authenticationExpiration
-  )
-  if (document[hidden]) {
+  if (!document[hidden]) {
     if (
       store.getters['auth/isAuthorized'] &&
       now >= authorizationExpiration &&

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -16,6 +16,7 @@ import TaskRunTableTile from '@/pages/FlowRun/TaskRunTable-Tile'
 import TileLayout from '@/layouts/TileLayout'
 import TileLayoutFull from '@/layouts/TileLayout-Full'
 import { parser } from '@/utils/markdownParser'
+import { FINISHED_STATES } from '@/utils/states'
 
 export default {
   metaInfo() {
@@ -196,7 +197,20 @@ export default {
         }
       },
       pollInterval: 5000,
-      update: data => data.flow_run_by_pk
+      update(data) {
+        if (!data) return
+
+        const flowRun = data.flow_run_by_pk
+        if (
+          FINISHED_STATES.includes(flowRun.state) &&
+          flowRun.state !== 'Scheduled'
+        ) {
+          this.$apollo.queries.flowRun.stopPolling()
+
+          this.$apollo.queries.flowRun.startPolling(60000)
+        }
+        return flowRun
+      }
     }
   }
 }
@@ -291,10 +305,13 @@ export default {
           <TimelineTile
             v-if="flowId"
             slot="row-0"
-            condensed
             :flow-id="flowId"
             :flow-run-id="flowRunId"
-            :flow-run="flowRun"
+            :flow-run-end-time="flowRun.end_time"
+            :flow-run-scheduled-start-time="flowRun.scheduled_start_time"
+            :flow-run-start-time="flowRun.start_time"
+            :flow-run-state="flowRun.state"
+            :flow-run-states="flowRun.states"
           />
 
           <DetailsTile slot="row-2-col-1-row-1-tile-1" :flow-run="flowRun" />

--- a/src/pages/FlowRun/Timeline-Tile.vue
+++ b/src/pages/FlowRun/Timeline-Tile.vue
@@ -211,7 +211,6 @@ export default {
       ])
     },
     isFinished() {
-      console.log('is finished')
       return (
         FINISHED_STATES.includes(this.flowRunState) &&
         this.flowRunState !== 'Scheduled'

--- a/src/pages/FlowRun/Timeline-Tile.vue
+++ b/src/pages/FlowRun/Timeline-Tile.vue
@@ -14,11 +14,6 @@ export default {
   },
   mixins: [formatTime],
   props: {
-    condensed: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
     flowId: {
       type: String,
       required: true
@@ -27,10 +22,35 @@ export default {
       type: String,
       required: true
     },
-    flowRun: {
-      type: Object,
+    // flowRun: {
+    //   type: Object,
+    //   required: false,
+    //   default: () => {}
+    // },
+    flowRunEndTime: {
+      type: String,
       required: false,
-      default: () => {}
+      default: () => null
+    },
+    flowRunScheduledStartTime: {
+      type: String,
+      required: false,
+      default: () => null
+    },
+    flowRunStartTime: {
+      type: String,
+      required: false,
+      default: () => null
+    },
+    flowRunState: {
+      type: String,
+      required: false,
+      default: () => null
+    },
+    flowRunStates: {
+      type: Array,
+      required: false,
+      default: () => []
     }
   },
   data() {
@@ -45,31 +65,31 @@ export default {
   computed: {
     containerStyle() {
       return {
-        height: this.condensed ? '114px' : 'calc(100vh - 350px)'
+        height: '114px'
       }
     },
     endTime() {
-      return this.flowRun.end_time && this.isFinished
+      return this.flowRunEndTime && this.isFinished
         ? Math.max.apply(null, [
-            new Date(this.flowRun.scheduled_start_time),
-            new Date(this.flowRun.end_time),
+            new Date(this.flowRunScheduledStartTime),
+            new Date(this.flowRunEndTime),
             this.maxEndTime
           ])
         : null
     },
     filteredFlowRunStates() {
-      return this.flowRun.states.filter(state => state.state !== 'Pending')
+      return this.flowRunStates.filter(state => state.state !== 'Pending')
     },
     startTime() {
-      return this.flowRun.start_time
+      return this.flowRunStartTime
         ? Math.min.apply(null, [
-            new Date(this.flowRun.scheduled_start_time),
-            new Date(this.flowRun.start_time),
+            new Date(this.flowRunScheduledStartTime),
+            new Date(this.flowRunStartTime),
             ...this.filteredFlowRunStates.map(
               state => new Date(state.start_time ?? state.timestamp)
             )
           ])
-        : this.flowRun.scheduled_start_time
+        : this.flowRunScheduledStartTime
     },
     loading() {
       return this.loadingKey > 0
@@ -187,13 +207,14 @@ export default {
     maxEndTime() {
       return Math.max.apply(null, [
         ...this.items.map(item => new Date(item.end_time)),
-        ...this.flowRun.states.map(state => new Date(state.timestamp))
+        ...this.flowRunStates.map(state => new Date(state.timestamp))
       ])
     },
     isFinished() {
+      console.log('is finished')
       return (
-        FINISHED_STATES.includes(this.flowRun.state) &&
-        this.flowRun.state !== 'Scheduled'
+        FINISHED_STATES.includes(this.flowRunState) &&
+        this.flowRunState !== 'Scheduled'
       )
     },
     mappedTaskRuns() {
@@ -212,9 +233,6 @@ export default {
         )
         .join(' ')
     },
-    pollInterval() {
-      return this.flowRun.state === 'Running' ? 1000 : 0
-    },
     taskRunMap() {
       if (!this.taskRuns || !this.tasks) return {}
       const taskRunMap = {}
@@ -231,17 +249,32 @@ export default {
   watch: {
     flowRun() {
       this.$apollo.queries.taskRuns.stopPolling()
+      this.$apollo.queries.tasks.stopPolling()
+      this.$apollo.queries.mappedChildren.stopPolling()
 
-      if (this.pollInterval > 0) {
-        this.$apollo.queries.taskRuns.startPolling(this.pollInterval)
+      if (this.isFinished) {
+        this.$apollo.queries.taskRuns.startPolling(60000)
+        this.$apollo.queries.mappedChildren.startPolling(60000)
       } else {
-        this.$apollo.queries.taskRuns.refetch()
+        this.$apollo.queries.taskRuns.startPolling(3000)
+        this.$apollo.queries.tasks.startPolling(30000)
+        this.$apollo.queries.mappedChildren.startPolling(5000)
       }
 
       this.generateBreakpoints()
     }
   },
   mounted() {
+    if (this.isFinished) {
+      this.$apollo.queries.taskRuns.stopPolling()
+      this.$apollo.queries.tasks.stopPolling()
+      this.$apollo.queries.mappedChildren.stopPolling()
+
+      this.$apollo.queries.taskRuns.startPolling(60000)
+      this.$apollo.queries.tasks.startPolling(60000)
+      this.$apollo.queries.mappedChildren.startPolling(60000)
+    }
+
     this.generateBreakpoints()
 
     this.containerHeight = getComputedStyle(
@@ -287,7 +320,7 @@ export default {
         return !this.flowId || !this.tasks
       },
       loadingKey: 'loadingKey',
-      pollInterval: 3000,
+      pollInterval: 60000,
       update: data => data.task_run
     },
     tasks: {
@@ -301,7 +334,6 @@ export default {
         return !this.flowRunId
       },
       loadingKey: 'loadingKey',
-      pollInterval: 5000,
       update: data => data.task
     },
     mappedChildren: {
@@ -315,7 +347,7 @@ export default {
       skip() {
         return !this.taskRuns || !this.mappedTaskRuns.length
       },
-      pollInterval: 5000,
+      pollInterval: 60000,
       update(data) {
         // Since mapped_children doesn't return an id (and we can't do this mapping with GraphQL)
         // we map those here instead
@@ -359,9 +391,11 @@ export default {
       class="timeline-container pa-0"
       style="height: 150px;"
     >
+      <!-- 
+            :condensed="condensed"
+        :min-bar-radius="10" -->
       <Timeline
         v-if="taskRuns && items"
-        :condensed="condensed"
         :items="items"
         :start-time="startTime"
         :end-time="endTime"
@@ -369,7 +403,6 @@ export default {
         :breakpoints="breakpoints"
         :live="!isFinished"
         :height="containerHeight"
-        :min-bar-radius="10"
         @breakpoint-hover="handleBreakpointHover"
         @hover="handleHover"
         @click="handleClick"

--- a/src/workers/timeline.js
+++ b/src/workers/timeline.js
@@ -1,0 +1,74 @@
+export function GenerateRows(items) {
+  const grid = []
+  const start = Date.now()
+  const end = Date.now()
+  const rowMap = {}
+
+  console.log(items)
+
+  itemLoop: for (let i = 0; i < items.length; ++i) {
+    const item = items[i]
+
+  // If the item hasn't started yet, we distribute
+  // it to the row with the least items already
+    if (!item.start_time) {
+      const lengths = grid.map(row => row.length)
+      let row = lengths.indexOf(Math.min(...lengths))
+
+      rowMap[item.id] = row
+
+      if (!grid[row]) {
+        grid.push([[start, end]])
+      } else {
+        grid[row].push([start, end])
+      }
+      
+      continue itemLoop
+    }
+
+    const start_ = item.start_time
+      ? new Date(item.start_time).getTime()
+      : null
+    const end_ = item.end_time
+      ? new Date(item.end_time).getTime()
+      : Date.now()
+
+    for (let row = 0; row <= grid.length; ++row) {
+      // If the current row doesn't exist, create it, put this item on it,
+      // and move to the next item
+      if (!grid[row]) {
+        rowMap[item.id] = row
+        grid.push([[start_, end_]])
+        continue itemLoop
+      }
+
+      if (!start_) {
+        const lengths = grid.map(row => row.length)
+        let row = lengths.indexOf(Math.min(...lengths))
+
+        rowMap[item.id] = row
+        grid[row].push([start_, end_])
+        continue itemLoop
+      }
+
+      // Otherwise check the start and end times against each
+      // start[0] and end[1] time in the row
+      let intersects = grid[row].some(
+        slot => end_ <= slot[0] - 2000 || start_ <= slot[1] + 2000
+      )
+
+      // let intersects = grid[row].some(
+      //   slot => end <= slot[0] || start <= slot[1]
+      // )
+
+      if (!intersects) {
+        rowMap[item.id] = row
+        grid[row].push([start_, end_])
+        continue itemLoop
+      }
+    }
+  }
+  console.log(rowMap, grid)
+
+  return { rowMap, rows: grid.length }
+}

--- a/src/workers/timeline.js
+++ b/src/workers/timeline.js
@@ -4,8 +4,6 @@ export function GenerateRows(items) {
   const end = Date.now()
   const rowMap = {}
 
-  console.log(items)
-
   itemLoop: for (let i = 0; i < items.length; ++i) {
     const item = items[i]
 
@@ -68,7 +66,6 @@ export function GenerateRows(items) {
       }
     }
   }
-  console.log(rowMap, grid)
 
   return { rowMap, rows: grid.length }
 }


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
- Reduces the number of computed props on the timeline component
- No longer passes the entire flow run object to the timeline tile to prevent unnecessary recomputes based on unchanged state 
- Reduces the frame rate cap on initial canvas render
- Drastically reduce the polling interval for flow runs in finished states.
- Moves grid calculation to a service worker
- Pause all timeline updates on background tabs

References: #663