### PR TITLE
Improve authorization expiration handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,12 @@
 ### Features and Improvements
 
 - Add the "Running" state to the state filter - [#675](https://github.com/PrefectHQ/ui/pull/675)
+- Add terminal link to apollo to abort requests with expired headers - [#690](https://github.com/PrefectHQ/ui/pull/690)
 
 ### Bugfixes
 
 - None
+
 ## 2021-03-16
 
 ### Bugfixes


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds a new terminal link to the apollo client chain that checks for a pre-set authorization expiration on all requests; requests whose authorization headers have expired aren't forwarded to the batch link.

Note: Given that almost-expired tokens are still valid I decided to go with a strict check instead; a future PR could add a buffer to the check (`almostExpired`?) to account for network latency but I'm not sure if this violates any assumptions on token handling.