### PR TITLE
fix artifact colors to be dark mode friendly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@
 
 ### Bugfixes
 
-- None
+- Make artifacts legible in dark mode - [#693](https://github.com/PrefectHQ/ui/pull/693)
 
 ## 2021-03-16
 

--- a/src/components/Artifacts/Artifact.vue
+++ b/src/components/Artifacts/Artifact.vue
@@ -30,7 +30,7 @@ export default {
 <template>
   <div
     v-if="artifact.kind == 'md' || artifact.kind == 'markdown'"
-    class="artifact md grey--text text--darken-3 mx-4"
+    class="artifact md utilGrayDark--text mx-4"
     v-html="mdParser(artifact.data.markdown)"
   >
   </div>

--- a/src/components/Artifacts/Artifacts.vue
+++ b/src/components/Artifacts/Artifacts.vue
@@ -142,7 +142,7 @@ export default {
       </div>
       <div
         v-else
-        class="text-center position-absolute center-absolute text-h5 grey--text text--darken-2"
+        class="text-center position-absolute center-absolute text-h5 utilGrayDark--text"
         style="z-index: 1;"
       >
         This run has no
@@ -169,7 +169,7 @@ export default {
           reverse-transition="quick-fade"
         >
           <v-card class="artifact-card pa-0" tile>
-            <v-card-title class="artifact-card-title white">
+            <v-card-title class="artifact-card-title">
               <div class="position-relative">
                 <v-icon x-large color="primary">fiber_manual_record</v-icon>
                 <v-icon
@@ -182,7 +182,7 @@ export default {
               </div>
               <div>
                 <div
-                  class="overline grey--text text--darken-1"
+                  class="overline utilGrayMid--text"
                   style="line-height: 1rem;"
                 >
                   Artifact


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes #680, makes artifact colors more dark mode friendly