### PR TITLE
Cut changelog ahead of 2021-03-25 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,16 +4,22 @@
 
 ### Features and Improvements
 
+- None
+
+### Bugfixes
+
+- None
+
+## 2021-03-25
+
+### Features and Improvements
+
 - Add default parameters to the schedules - [#683](https://github.com/PrefectHQ/ui/pull/683)
 - Add the "Running" state to the state filter - [#675](https://github.com/PrefectHQ/ui/pull/675)
 - Add terminal link to apollo to abort requests with expired headers - [#690](https://github.com/PrefectHQ/ui/pull/690)
 - Use `delete_flow_group` mutation when deleting flows - [#689](https://github.com/PrefectHQ/ui/pull/689)
 - Flow run page performance improvements (part 1) and shared service worker for token refresh - [#679](https://github.com/PrefectHQ/ui/pull/679)
 - Flow run page performance improvements (part 2) - [#688](https://github.com/PrefectHQ/ui/pull/688)
-
-### Bugfixes
-
-- None
 
 ## 2021-03-16
 


### PR DESCRIPTION
## 2021-03-25

### Features and Improvements

- Add default parameters to the schedules - [#683](https://github.com/PrefectHQ/ui/pull/683)
- Add the "Running" state to the state filter - [#675](https://github.com/PrefectHQ/ui/pull/675)
- Add terminal link to apollo to abort requests with expired headers - [#690](https://github.com/PrefectHQ/ui/pull/690)
- Use `delete_flow_group` mutation when deleting flows - [#689](https://github.com/PrefectHQ/ui/pull/689)
- Flow run page performance improvements (part 1) and shared service worker for token refresh - [#679](https://github.com/PrefectHQ/ui/pull/679)
- Flow run page performance improvements (part 2) - [#688](https://github.com/PrefectHQ/ui/pull/688)
