### PR TITLE
Make the duration header not sortable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ### Bugfixes
 
+- Make the duration header not sortable - [#699](https://github.com/PrefectHQ/ui/pull/699)
 - Fix a bug where double clicking could kick off multiple quick runs - [#696](https://github.com/PrefectHQ/ui/pull/696)
 - Make artifacts legible in dark mode - [#693](https://github.com/PrefectHQ/ui/pull/693)
 

--- a/src/pages/Flow/FlowRunTable-Tile.vue
+++ b/src/pages/Flow/FlowRunTable-Tile.vue
@@ -39,7 +39,13 @@ export default {
           width: '18%'
         },
         { text: 'End Time', value: 'end_time', align: 'start', width: '18%' },
-        { text: 'Duration', value: 'duration', align: 'end', width: '15%' },
+        {
+          text: 'Duration',
+          value: 'duration',
+          align: 'end',
+          width: '15%',
+          sortable: false
+        },
         { text: 'State', value: 'state', align: 'end', width: '10%' }
       ],
       itemsPerPage: 15,

--- a/src/pages/FlowRun/TaskRunTable-Tile.vue
+++ b/src/pages/FlowRun/TaskRunTable-Tile.vue
@@ -47,7 +47,13 @@ export default {
           width: '20%'
         },
         { text: 'End Time', value: 'end_time', align: 'start', width: '15%' },
-        { text: 'Duration', value: 'duration', align: 'end', width: '17.5%' },
+        {
+          text: 'Duration',
+          value: 'duration',
+          align: 'end',
+          width: '17.5%',
+          sortable: false
+        },
         { text: 'State', value: 'state', align: 'end', width: '10%' },
         {
           text: '',

--- a/src/pages/Task/TaskRunTable-Tile.vue
+++ b/src/pages/Task/TaskRunTable-Tile.vue
@@ -38,7 +38,13 @@ export default {
           width: '20%'
         },
         { text: 'End Time', value: 'end_time', align: 'start', width: '20%' },
-        { text: 'Duration', value: 'duration', align: 'end', width: '15%' },
+        {
+          text: 'Duration',
+          value: 'duration',
+          align: 'end',
+          width: '15%',
+          sortable: false
+        },
         { text: 'State', value: 'state', align: 'end', width: '15%' }
       ],
       itemsPerPage: 15,


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This will make the duration header not sortable since the `duration` field has been removed from the database

Related
#687 
#265 