### PR TITLE
Usage timeline bugfixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Make the duration header not sortable - [#699](https://github.com/PrefectHQ/ui/pull/699)
 - Fix a bug where double clicking could kick off multiple quick runs - [#696](https://github.com/PrefectHQ/ui/pull/696)
 - Make artifacts legible in dark mode - [#693](https://github.com/PrefectHQ/ui/pull/693)
+- Usage timeline bugfixes - [#722](https://github.com/PrefectHQ/ui/pull/722)
 
 ## 2021-03-25
 

--- a/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
+++ b/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
@@ -434,7 +434,9 @@ export default {
         0.8
 
       const bandwidth = maxBandwidth < 75 ? maxBandwidth : 75
-      const bandwidthNoPadding = (this.width - this.padding.x) / this.ticks
+      const bandwidthNoPadding =
+        (this.width - this.padding.left * 2 - this.padding.right * 2) /
+        this.ticks
 
       const xAxis = d3
         .axisBottom(this.x)

--- a/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
+++ b/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
@@ -26,7 +26,7 @@ export default {
       id: uniqueId('usage'),
       format: null,
       ticks: null,
-      period: 'Week',
+      period: 'Year',
       hoverGroup: null,
       interactionGroup: null,
       mainGroup: null,

--- a/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
+++ b/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
@@ -12,7 +12,6 @@ const d3 = Object.assign({}, d3_base, d3_regression)
 const xAxisHeight = 40
 
 const startDate = new Date('2018-01-17T00:00:00+00:00')
-// const daysInMonth = (month, year) => new Date(year, month, 0).getDate()
 
 export default {
   props: {
@@ -27,7 +26,7 @@ export default {
       id: uniqueId('usage'),
       format: null,
       ticks: null,
-      period: 'Year', // tooltip centering, plan updates need refresh
+      period: 'Week',
       hoverGroup: null,
       interactionGroup: null,
       mainGroup: null,
@@ -201,24 +200,24 @@ export default {
         from.setFullYear(year - 1 + this.offset)
         from.setDate(0)
       } else if (this.period == 'Month') {
-        from.setDate(0)
-        from.setMinutes(1)
+        from.setDate(1)
         from.setMonth(from.getMonth() + this.offset)
       } else if (this.period == 'Week') {
         const day = from.getDay()
         const diff = from.getDate() + this.offset - ((day + 6) % 7)
-        from.setMinutes(0)
         from.setDate(diff)
       }
 
       from.setMilliseconds(0)
       from.setSeconds(0)
+      from.setMinutes(0)
       from.setHours(0)
       return from
     },
     to() {
       const to = new Date()
       to.setHours(23)
+      to.setSeconds(59)
       if (this.period == 'Year') {
         const year = new Date().getFullYear()
         to.setFullYear(year + this.offset)
@@ -230,11 +229,15 @@ export default {
         to.setDate(0)
         to.setMinutes(59)
       } else if (this.period == 'Week') {
-        const diff = to.getDate() + this.offset + (6 - to.getDay())
+        const day = to.getDay()
+        const diff = to.getDate() + this.offset + (7 - day)
         to.setDate(diff)
-        to.setMinutes(60)
       }
 
+      to.setMilliseconds(999)
+      to.setSeconds(59)
+      to.setMinutes(59)
+      to.setHours(23)
       return to
     },
     decrementOffsetDisabled() {
@@ -644,7 +647,6 @@ export default {
       //       )
       //   )
       const start = this.padding.left * 2
-
       const xPosition = (d, i) =>
         start + (bandwidthNoPadding * i - bandwidth / 2)
       const yPosition = d => (d.runs ? this.y(d.runs) : yOffset)

--- a/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
+++ b/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
@@ -340,11 +340,9 @@ export default {
 
       this.boundingClientRect = this.$refs['parent']?.getBoundingClientRect()
 
-      this.width = Math.floor(parent.clientWidth - padding.left - padding.right)
+      this.width = parent.clientWidth - padding.left - padding.right
 
-      this.height = Math.floor(
-        parent.clientHeight - padding.top - padding.bottom
-      )
+      this.height = parent.clientHeight - padding.top - padding.bottom
 
       this.chart.attr('viewbox', `0 0 ${this.width} ${this.height}`)
 
@@ -429,9 +427,8 @@ export default {
       const yOffset = this.height - this.padding.y
 
       const maxBandwidth =
-        ((this.width - this.padding.left * 2 - this.padding.right * 2) /
-          this.ticks) *
-        0.8
+        (this.width - this.padding.left * 2 - this.padding.right * 2) /
+        this.ticks
 
       const bandwidth = maxBandwidth < 75 ? maxBandwidth : 75
       const bandwidthNoPadding =
@@ -621,8 +618,10 @@ export default {
       //           .attr('d', this.line)
       //       )
       //   )
+      const start = this.padding.left * 2
 
-      const xPosition = d => this.x(new Date(d.timestamp)) - bandwidth / 2
+      const xPosition = (d, i) =>
+        start + (bandwidthNoPadding * i - bandwidth / 2)
       const yPosition = d => (d.runs ? this.y(d.runs) : yOffset)
       const height = d => (d.runs ? yOffset - this.y(d.runs) : 0)
 

--- a/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
+++ b/src/pages/TeamSettings/Account/Usage/UsageTimeline.vue
@@ -428,9 +428,11 @@ export default {
       if (!this.chart) return
       const yOffset = this.height - this.padding.y
 
-      const maxBandwidth = Math.floor(
-        ((this.width - this.padding.x) / this.ticks) * 0.8
-      )
+      const maxBandwidth =
+        ((this.width - this.padding.left * 2 - this.padding.right * 2) /
+          this.ticks) *
+        0.8
+
       const bandwidth = maxBandwidth < 75 ? maxBandwidth : 75
       const bandwidthNoPadding = (this.width - this.padding.x) / this.ticks
 
@@ -621,16 +623,19 @@ export default {
       const xPosition = d => this.x(new Date(d.timestamp)) - bandwidth / 2
       const yPosition = d => (d.runs ? this.y(d.runs) : yOffset)
       const height = d => (d.runs ? yOffset - this.y(d.runs) : 0)
-      const transform = `translate(${bandwidth / 2 ?? 0}px)`
-      const textContent = d =>
-        d.runs
-          ? d.runs?.toLocaleString() +
-            ' - ' +
-            new Date(d.timestamp).toLocaleString('en-US', {
-              dateStyle: 'short',
-              timeStyle: undefined
-            })
-          : null
+
+      // These are used for the text labels on the bars
+      // which are unused at the moment
+      // const transform = `translate(${bandwidth / 2 ?? 0}px)`
+      // const textContent = d =>
+      //   d.runs
+      //     ? d.runs?.toLocaleString() +
+      //       ' - ' +
+      //       new Date(d.timestamp).toLocaleString('en-US', {
+      //         dateStyle: 'short',
+      //         timeStyle: undefined
+      //       })
+      //     : null
 
       this.mainGroup.style('transform', `translate(0, ${this.padding.top}px)`)
 
@@ -660,15 +665,15 @@ export default {
               .attr('x', xPosition)
               .attr('y', yOffset)
 
-            g.append('text')
-              .attr('x', xPosition)
-              .attr('y', yOffset - 5)
-              .style('text-anchor', 'middle')
-              .style('user-select', 'none')
-              .style('transform', transform)
-              .style('font', '10px Roboto, sans-serif')
-              .attr('fill', 'transparent')
-              .text(textContent)
+            // g.append('text')
+            //   .attr('x', xPosition)
+            //   .attr('y', yOffset - 5)
+            //   .style('text-anchor', 'middle')
+            //   .style('user-select', 'none')
+            //   .style('transform', transform)
+            //   .style('font', '10px Roboto, sans-serif')
+            //   .attr('fill', 'transparent')
+            //   .text(textContent)
 
             return g.call(enter => {
               enter
@@ -680,17 +685,17 @@ export default {
                 .attr('height', height)
                 .attr('y', yPosition)
 
-              enter
-                .select('text')
-                .transition('enter')
-                .duration(1000)
-                .delay(250)
-                .ease(d3.easeQuad)
-                .attr('y', d =>
-                  d.runs ? yPosition(d) - 5 : yOffset + this.padding.y
-                )
-                .style('font', '10px Roboto, sans-serif')
-                .attr('fill', this.showText ? '#546E7A' : 'transparent')
+              // enter
+              //   .select('text')
+              //   .transition('enter')
+              //   .duration(1000)
+              //   .delay(250)
+              //   .ease(d3.easeQuad)
+              //   .attr('y', d =>
+              //     d.runs ? yPosition(d) - 5 : yOffset + this.padding.y
+              //   )
+              //   .style('font', '10px Roboto, sans-serif')
+              //   .attr('fill', this.showText ? '#546E7A' : 'transparent')
 
               return enter
             })
@@ -713,17 +718,17 @@ export default {
                 .attr('width', bandwidth)
                 .attr('x', xPosition)
 
-              update
-                .select('text')
-                .transition('update')
-                .duration(1000)
-                .delay(500)
-                .ease(d3.easeQuad)
-                .attr('fill', this.showText ? '#546E7A' : 'transparent')
-                .attr('y', d =>
-                  d.runs ? yPosition(d) - 5 : yOffset + this.padding.y
-                )
-                .attr('x', xPosition)
+              // update
+              //   .select('text')
+              //   .transition('update')
+              //   .duration(1000)
+              //   .delay(500)
+              //   .ease(d3.easeQuad)
+              //   .attr('fill', this.showText ? '#546E7A' : 'transparent')
+              //   .attr('y', d =>
+              //     d.runs ? yPosition(d) - 5 : yOffset + this.padding.y
+              //   )
+              //   .attr('x', xPosition)
             })
           },
           exit =>


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes:
- Issues with overlapping bars; bar positions were being calculated based on fixed width buckets on a continuous time scale 🙅 
- Issues where the invisible interaction areas were overlapping
- The bars no longer attempt to set negative heights caused by the chart updating before dimensions had been set; we're no longer using `requestAnimationFrame` for the initial resize call in the `mounted` hook, and we're calling the raw method instead of the throttled one to prevent the race condition altogether
- Fixes an issue where period boundaries weren't quite what we wanted them to be; months should now span only the days in the month, and weeks should go from Mon-Sun