### PR TITLE
Committed runs on license instead of tenant patch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix an issue where we weren't correctly passing the license id to the committed usage query - [#741](https://github.com/PrefectHQ/ui/pull/741)
 
 ## 2021-04-05
 

--- a/src/pages/Dashboard/UsageTiles/CommittedUsage-Tile.vue
+++ b/src/pages/Dashboard/UsageTiles/CommittedUsage-Tile.vue
@@ -36,7 +36,7 @@ export default {
       query: require('@/graphql/Dashboard/committed-usage.gql'),
       variables() {
         return {
-          license: this.license?.id
+          license_id: this.license?.id
         }
       },
       skip() {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes an issue where we weren't correctly passing the license ID to the committed usage tile. 