### PR TITLE
Update all slack invite links to redirect to the prefect.io slack link

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Remove all static Slack invite links in favor of the centralized prefect.io/slack link - [#747](https://github.com/PrefectHQ/ui/pull/747)
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
       <img src="https://api.netlify.com/api/v1/badges/effeac10-a905-46ee-8e93-b59454ecc8bb/deploy-status" alt="Netlify Build Status" alt="Netlify status badge">
    </a>
 
-   <a href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE">
+   <a href="https://prefect.io/slack">
       <img src="https://prefect-slackin.herokuapp.com/badge.svg" alt="Slack members status badge">
    </a>
 </p>
 <p align="center">
-<a href="https://prefect.io">
+   <a href="https://prefect.io">
     <img src="https://images.ctfassets.net/gm98wzqotmnx/3mwImS57DEydMQXU1FCGG/6e36e2d49faf78cf4a166f123c2c43ca/image__5_.png" height="27" alt="Powered By Prefect">
     </a>
 </p>

--- a/src/components/HavingTrouble.vue
+++ b/src/components/HavingTrouble.vue
@@ -11,8 +11,7 @@ export default { components: { ExternalLink } }
     </div>
     <div class="mt-4">
       The <v-icon x-small>fab fa-slack</v-icon>&nbsp;
-      <ExternalLink
-        href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE"
+      <ExternalLink href="https://prefect.io/slack"
         >Prefect Slack community</ExternalLink
       >
       is a great place to ask questions, provide feedback, or just to chat!

--- a/src/components/Nav/HelpMenu.vue
+++ b/src/components/Nav/HelpMenu.vue
@@ -97,10 +97,7 @@ export default {
           </v-list-item-content>
         </v-list-item>
 
-        <v-list-item
-          href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE"
-          target="_blank"
-        >
+        <v-list-item href="https://prefect.io/slack" target="_blank">
           <v-list-item-avatar tile class="d-flex justify-center align-center">
             <img src="@/assets/icon-illustrations/slack-community.svg" />
           </v-list-item-avatar>

--- a/src/components/Schematics/Schematic-Flow.vue
+++ b/src/components/Schematics/Schematic-Flow.vue
@@ -1075,9 +1075,7 @@ export default {
               Thanks! We'll get our team on it immediately.
             </div>
             By the way, you can
-            <a
-              target="_blank"
-              href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE"
+            <a target="_blank" href="https://prefect.io/slack"
               >join our Slack</a
             >
             to ask questions, provide feedback, or just to chat! You can also

--- a/src/pages/Home/Home.vue
+++ b/src/pages/Home/Home.vue
@@ -29,8 +29,7 @@ const exploreBlocks = [
     body: 'Chat with us, ask questions, and share tips',
     src: require('@/assets/icon-illustrations/slack-community.svg'),
     alt: 'Join the community image',
-    href:
-      'https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE',
+    href: 'https://prefect.io/slack',
     linkText: 'Join Slack'
   }
 ]

--- a/src/pages/Onboard/Resources.vue
+++ b/src/pages/Onboard/Resources.vue
@@ -102,10 +102,7 @@ export default {
                 Chat with us, ask questions, and share tips
               </div>
               <div>
-                <v-btn
-                  target="_blank"
-                  href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE"
-                >
+                <v-btn target="_blank" href="https://prefect.io/slack">
                   Join Slack
                 </v-btn>
               </div>
@@ -169,7 +166,7 @@ export default {
                       light
                       depressed
                       target="_blank"
-                      href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE"
+                      href="https://prefect.io/slack"
                     >
                       Join Slack
                     </v-btn>

--- a/src/pages/Support.vue
+++ b/src/pages/Support.vue
@@ -178,9 +178,7 @@ export default {
                       If you haven't already,
                     </span>
 
-                    <a
-                      target="_blank"
-                      href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE"
+                    <a target="_blank" href="https://prefect.io/slack"
                       >join our Slack</a
                     >
                     to ask questions, provide feedback, or just to chat! You can
@@ -231,7 +229,7 @@ export default {
             dark
             depressed
             target="_blank"
-            href="https://join.slack.com/t/prefect-community/shared_invite/enQtODQ3MTA2MjI4OTgyLTliYjEyYzljNTc2OThlMDE4YmViYzk3NDU4Y2EzMWZiODM0NmU3NjM0NjIyNWY0MGIxOGQzODMxNDMxYWYyOTE"
+            href="https://prefect.io/slack"
           >
             Join Slack
           </v-btn>


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Replaces Slack invite links with a centralized link to prefect.io; removes redirects to heroku app.