### PR TITLE
fix legibility issues with /plans page in dark mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fixes illegible /plans page when in dark mode - [#748](https://github.com/PrefectHQ/ui/pull/748)
 
 ## 2021-04-06a
 

--- a/src/components/Plans/Standard.vue
+++ b/src/components/Plans/Standard.vue
@@ -47,7 +47,9 @@ export default {
 
 <template>
   <div class="plan-card white rounded elevation-7">
-    <div class="font-weight-regular text-center py-8 plan-title">
+    <div
+      class="font-weight-regular secondaryGrayDark--text text-center py-8 plan-title"
+    >
       Standard
       <div v-if="!hideDetails" class="text-body-1 prefect--text text-none">
         Recommended
@@ -140,7 +142,7 @@ export default {
         </MenuTooltip>
 
         <div
-          class="my-12 my-md-8 my-lg-12 text-left plan-body d-flex align-start justify-center flex-column"
+          class="my-12 my-md-8 my-lg-12 text-left plan-body d-flex align-start justify-center flex-column secondaryGrayDark--text"
         >
           <div class="d-flex align-center justify-center">
             <span class="rounded-circle plans-feature-icon">
@@ -295,7 +297,7 @@ export default {
 
   .plan-cta {
     background-color: #f7fcfd;
-    color: inherit !important;
+    color: var(--v-secondaryGrayDark-base);
     display: block;
     font-size: 1rem;
     letter-spacing: 0.15rem;

--- a/src/components/Plans/Starter.vue
+++ b/src/components/Plans/Starter.vue
@@ -84,7 +84,7 @@ export default {
             <div class="font-weight-regular">
               +
 
-              <a class="prefect--text text--lighten-1 volume-link"
+              <a class="primary--text text--lighten-1 volume-link"
                 >automatic volume discounts</a
               >
             </div></template

--- a/src/pages/Plans.vue
+++ b/src/pages/Plans.vue
@@ -179,10 +179,7 @@ export default {
     </div>
 
     <transition name="quick-fade">
-      <div
-        v-if="!complete"
-        class="features-container blue-grey--text text--darken-3"
-      >
+      <div v-if="!complete" class="features-container utilGrayDark--text">
         <div class="text-center text-h3 font-weight-light">Features</div>
 
         <div class="text-center mt-8">
@@ -258,10 +255,9 @@ export default {
                   >
                     <template #activator>
                       <div
-                        class="d-flex justify-start align-center blue-grey--text flex-grow-1 feature-list-title"
+                        class="d-flex justify-start align-center utilGrayDark--text flex-grow-1 feature-list-title"
                         :class="{
-                          'text--lighten-4':
-                            feature.value && planValue < feature.value
+                          'o-50': feature.value && planValue < feature.value
                         }"
                         style="transition: all 150ms ease-in-out;"
                       >
@@ -293,7 +289,9 @@ export default {
                       </div>
                     </template>
 
-                    <div class="blue-grey--text text--darken-1 text-subtitle-1">
+                    <div
+                      class="utilGrayDark--text text--darken-1 text-subtitle-1"
+                    >
                       {{ feature.description }}
                       <div
                         v-if="feature.plan == 'enterprise'"
@@ -343,7 +341,7 @@ export default {
         </div>
 
         <v-card
-          class="white pa-8 margin-auto support-card elevation-4 rounded d-flex align-start justify-start"
+          class="pa-8 margin-auto support-card elevation-4 rounded d-flex align-start justify-start"
           tile
         >
           <div class="d-inline-block support-icon">
@@ -352,11 +350,11 @@ export default {
 
           <v-row class="ml-4" no-gutters>
             <v-col cols="12" sm="8">
-              <div class="text-h4 font-weight-light pa-0">
+              <div class="utilGrayDark--text text-h4 font-weight-light pa-0">
                 <span>Premium Support</span>
               </div>
               <div
-                class="mt-2 text-h6 font-weight-light blue-grey--text text--darken-1 pa-0"
+                class="mt-2 text-h6 font-weight-light utilGrayDark--text pa-0"
               >
                 A support plan built to help you quickly grow your workflows.
 
@@ -389,7 +387,7 @@ export default {
                   Support built for you
                 </div>
                 <a
-                  class="support-link text-h6 font-weight-regular mt-4"
+                  class="utilGrayDark--text support-link text-h6 font-weight-regular mt-4"
                   href="https://www.prefect.io/pricing#contact"
                   target="_blank"
                   >Contact us
@@ -536,7 +534,7 @@ export default {
   width: 450px;
 
   a {
-    background: #27b1ff;
+    background: var(--v-primary-base);
     border-radius: 4px;
     height: 100%;
     position: absolute;
@@ -581,6 +579,7 @@ export default {
     background-color: #eee;
     border-radius: 4px;
     box-sizing: content-box;
+    color: var(--v-secondaryGrayDark-base);
     display: flex;
     margin-top: 8px;
     overflow: hidden;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -459,8 +459,8 @@ $percents: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100;
   width: 20px;
 
   .svg-inline--fa {
-    --fa-primary-color: var(--v-prefect-base);
-    --fa-secondary-color: var(--v-prefect-base);
+    --fa-primary-color: var(--v-primary-base);
+    --fa-secondary-color: var(--v-primary-base);
     --fa-secondary-opacity: 0.6;
     transition: all 150ms linear;
   }
@@ -481,7 +481,7 @@ $percents: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100;
 
   &.plans-feature-icon-light {
     .svg-inline--fa {
-      --fa-primary-color: var(--v-prefect-base);
+      --fa-primary-color: var(--v-primary-base);
       --fa-secondary-color: var(--v-primaryLight-base);
       --fa-secondary-opacity: 1;
     }
@@ -490,14 +490,14 @@ $percents: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100;
 
 .feature-category-icon {
   .svg-inline--fa {
-    --fa-primary-color: var(--v-prefect-base);
+    --fa-primary-color: var(--v-primary-base);
     --fa-secondary-color: var(--v-accentPink-base);
     --fa-secondary-opacity: 1;
     transition: all 150ms linear;
 
     &.fa-chart-scatter {
       --fa-primary-color: var(--v-accentPink-base);
-      --fa-secondary-color: var(--v-prefect-base);
+      --fa-secondary-color: var(--v-primary-base);
     }
   }
 }
@@ -529,15 +529,14 @@ $percents: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100;
 
 .support-icon {
   .svg-inline--fa {
-    --fa-primary-color: var(--v-prefect-base);
-    --fa-secondary-color: var(--v-prefect-base);
+    --fa-primary-color: var(--v-primary-base);
+    --fa-secondary-color: var(--v-primary-base);
     --fa-secondary-opacity: 0.5;
   }
 
   .fa-badge-check.svg-inline--fa {
     --fa-primary-color: var(--v-accentGreen-darken2);
     --fa-secondary-color: var(--v-accentGreen-base);
-    --fa-secondary-opacity: 0.6;
   }
 }
 /* stylelint-enable no-descending-specificity */


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes #715, makes /plans legible in dark mode as well as normal