### PR TITLE
add breadcrumb to flow version, change flow name breadcrumb to overview

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Features and Improvements
 
+- Adds breadcrumb to allow easy access to current flow version and spawning flow version from a flow run screen [#759](https://github.com/PrefectHQ/ui/pull/759)
 - Add a label specifying which flow version the flow run has spawned from[#736](https://github.com/PrefectHQ/ui/pull/736)
 - Adds a tenant selector to User > API Keys creation screen [#753](https://github.com/PrefectHQ/ui/pull/753)
 

--- a/src/graphql/FlowRun/flow-run.js
+++ b/src/graphql/FlowRun/flow-run.js
@@ -53,6 +53,7 @@ export default function(isCloud) {
           core_version
           parameters
           archived
+          flow_group_id
           project {
             id
             name

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -272,9 +272,19 @@ export default {
             {
               route: {
                 name: 'flow',
-                params: { id: flowRun.flow.id }
+                params: { id: flowRun.flow.flow_group_id }
               },
               text: flowRun.flow.name
+            },
+            {
+              route: {
+                name: 'flow',
+                params: { id: flowRun.flow.id }
+              },
+              text:
+                flowRun.flow.version == flowRun.version
+                  ? `Version ${flowRun.flow.version} (Current)`
+                  : `Version ${flowRun.flow.version}`
             }
           ]"
         />


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Addresses #649 by adding an additional breadcrumb. Flow name will always go to overview/latest version, version crumb will go to that specific version. Also helps make it more obvious what version of a flow a run is attached to, in case folks needed that (though 736 does very similar...).