### PR TITLE
Add logging level to run config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Adds animated hint for users creating new automations - [#784](https://github.com/PrefectHQ/ui/pull/784)
 - Adds a loading indicator for inital page load - [#789](https://github.com/PrefectHQ/ui/pull/789)
 - Take usage tile off dashboard and add to account page - [#782](https://github.com/PrefectHQ/ui/pull/782)
+- Add dropdown to specify logging level on flow runs [#769](https://github.com/PrefectHQ/ui/pull/769)
 
 ### Bugfixes
 

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -501,7 +501,17 @@ export default {
                 <template #item="{ item }">
                   <div>
                     <v-chip
-                      class="ma-2 debuglevel"
+                      class="ma-2 debuglevel cursor-pointer"
+                      :class="item.text.toLowerCase()"
+                    >
+                      {{ item.text }}
+                    </v-chip>
+                  </div>
+                </template>
+                <template #selection="{ item }">
+                  <div>
+                    <v-chip
+                      class="ma-2 debuglevel cursor-pointer"
                       :class="item.text.toLowerCase()"
                     >
                       {{ item.text }}

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -828,9 +828,7 @@ export default {
     width: 100%;
   }
 }
-</style>
 
-<style lang="scss">
 .ma-2.debuglevel {
   color: var(--v-utilGrayLight-lighten5);
   font-weight: bold;
@@ -861,7 +859,9 @@ export default {
     background: var(--v-failRed-base);
   }
 }
+</style>
 
+<style lang="scss">
 .run-tab-icon {
   .svg-inline--fa {
     --fa-primary-color: var(--v-appForeground-base);

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -830,7 +830,7 @@ export default {
 }
 
 .ma-2.debuglevel {
-  color: var(--v-utilGrayLight-lighten5);
+  color: var(--v-primaryLight-lighten5);
   font-weight: bold;
   justify-content: center;
   width: 75px;

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -489,7 +489,7 @@ export default {
                     </p>
                     <p>
                       Please note this is only guaranteed to work for Agents
-                      running Prefect Core TODO or later.
+                      running Prefect Core 0.14.17 or later.
                     </p>
                   </MenuTooltip>
                 </div>

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -42,6 +42,17 @@ export default {
     return {
       stickyActions: false,
 
+      // Logging Level
+      loggingLevel: 'DEFAULT',
+      loggingLevels: [
+        { text: 'Default', value: 'DEFAULT' },
+        { text: 'Debug', value: 'DEBUG' },
+        { text: 'Info', value: 'INFO' },
+        { text: 'Warn', value: 'WARN' },
+        { text: 'Error', value: 'ERROR' },
+        { text: 'Critical', value: 'CRITICAL' }
+      ],
+
       // Parameters
       parameters: null,
 
@@ -149,7 +160,9 @@ export default {
 
       try {
         this.loading = true
-
+        // if the user has specified a logging level, pass it
+        // to the run config as an env var
+        this.overrideLoggingEnvironmentVariable()
         const { data, errors } = await this.$apollo.mutate({
           mutation: require('@/graphql/Mutations/create-flow-run.gql'),
           variables: {
@@ -209,6 +222,14 @@ export default {
         alertMessage: errorMessage,
         alertType: 'error'
       })
+    },
+    overrideLoggingEnvironmentVariable() {
+      if (this.loggingLevel !== 'DEFAULT') {
+        this.runConfig.env = {
+          ...this.runConfig.env,
+          PREFECT__LOGGING__LEVEL: this.loggingLevel
+        }
+      }
     },
     validContext() {
       if (!this.$refs.contextRef) {
@@ -442,6 +463,53 @@ export default {
               @input="handleLabelInput"
             />
           </v-col>
+        </v-row>
+
+        <v-row v-if="showAdvanced" class="my-2 py-8 row-divider" no-gutters>
+          <v-row class="my-2 py-8" no-gutters>
+            <v-col cols="12" md="3">
+              <div
+                class="py-0"
+                :class="{ 'pr-24': $vuetify.breakpoint.mdAndUp }"
+              >
+                <div class="text-h5">
+                  Logging Level
+                  <MenuTooltip>
+                    <p>
+                      Logging level for the flow run. If none is specified,
+                      default agent logging level will be used.
+                    </p>
+                    <p>
+                      This can also be controlled by providing an environment
+                      variable, "PREFECT__LOGGING__LEVEL".
+                    </p>
+                    <p>
+                      Any dropdown selection besides "Default" will override the
+                      environment variable.
+                    </p>
+                    <p>
+                      Please note this is only guaranteed to work for Agents
+                      running Prefect Core TODO or later.
+                    </p>
+                  </MenuTooltip>
+                </div>
+              </div>
+            </v-col>
+
+            <v-col cols="12" md="9" class="mt-n4 mt-md-0">
+              <v-select v-model="loggingLevel" outlined :items="loggingLevels">
+                <template #item="{ item }">
+                  <div>
+                    <v-chip
+                      :class="['ma-2', 'debuglevel', item.text.toLowerCase()]"
+                    >
+                      {{ item.text }}
+                    </v-chip>
+                  </div>
+                </template>
+              </v-select>
+            </v-col>
+          </v-row>
         </v-row>
 
         <v-row v-if="showAdvanced" class="my-2 py-8 row-divider" no-gutters>
@@ -763,6 +831,37 @@ export default {
 </style>
 
 <style lang="scss">
+.ma-2.debuglevel {
+  color: var(--v-utilGrayLight-lighten5);
+  font-weight: bold;
+  justify-content: center;
+  width: 75px;
+
+  &.default {
+    background: var(--v-success-lighten2);
+  }
+
+  &.error {
+    background: var(--v-error-lighten2);
+  }
+
+  &.warn {
+    background: var(--v-warning-lighten1);
+  }
+
+  &.info {
+    background: var(--v-info-lighten2);
+  }
+
+  &.debug {
+    background: var(--v-Looped-lighten2);
+  }
+
+  &.critical {
+    background: var(--v-failRed-base);
+  }
+}
+
 .run-tab-icon {
   .svg-inline--fa {
     --fa-primary-color: var(--v-appForeground-base);

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -501,7 +501,8 @@ export default {
                 <template #item="{ item }">
                   <div>
                     <v-chip
-                      :class="['ma-2', 'debuglevel', item.text.toLowerCase()]"
+                      class="ma-2 debuglevel"
+                      :class="item.text.toLowerCase()"
                     >
                       {{ item.text }}
                     </v-chip>

--- a/src/utils/runConfigs.js
+++ b/src/utils/runConfigs.js
@@ -27,7 +27,14 @@ export const UniversalRun = {
   description: 'Run the flow on any agent with matching labels',
   ref: 'https://docs.prefect.io/api/latest/run_configs.html#universalrun',
   icon: 'fad fa-globe',
-  args: []
+  args: [
+    {
+      arg: 'env',
+      input_type: 'object',
+      label: 'Environment variables',
+      description: 'Additional environment variables to set in the container.'
+    }
+  ]
 }
 
 export const DockerRun = {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

This PR adds a drop down to the Run page, allowing users to specify logging level for a flow run.

I've never worked with Vue before, please be gentle :).

Open questions
- Testing. Based on the tests folder, it didn't seem like `Run.vue` was being tested? I assume I'm missing something here. If you can direct me to the right file, I'm happy to write the appropriate tests.

TODO
- [x] Confirm styling works well on both light and dark mode
- [x] Update tooltip with Core version once this PR is merged and released PrefectHQ/prefect#4383