### PR TITLE
don't save backend in localstorage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 ### Bugfixes
 
 - Make team creation error text more legible - [#767](https://github.com/PrefectHQ/ui/pull/767)
+- Don't allow non-Cloud users to get stuck in a redirect loop if they try out the toggle - [#772](https://github.com/PrefectHQ/ui/pull/772)
 
 ## 2021-04-09a
 

--- a/src/store/api/index.js
+++ b/src/store/api/index.js
@@ -6,8 +6,7 @@ const SERVER_KEY = `${process.env.VUE_APP_RELEASE_TIMESTAMP}_server_url`
 const maxRetries = 3
 
 const state = {
-  backend:
-    localStorage.getItem('backend') || process.env.VUE_APP_BACKEND || 'SERVER',
+  backend: process.env.VUE_APP_BACKEND || 'SERVER',
   connected: true,
   connectionMessage: null,
   connectionTimeout: null,
@@ -81,11 +80,9 @@ const mutations = {
       throw new Error('Invalid backend')
     }
     state.backend = backend
-    localStorage.setItem('backend', backend)
   },
   unsetBackend(state) {
     state.backend = null
-    localStorage.removeItem('backend')
   },
   setConnected(state, connected) {
     if (typeof connected !== 'boolean') {

--- a/tests/unit/store/api.spec.js
+++ b/tests/unit/store/api.spec.js
@@ -220,14 +220,6 @@ describe('API Vuex Module', () => {
         store.commit('unsetBackend')
         expect(store.getters['backend']).toEqual(null)
       })
-      it('should remove backend from localstorage', () => {
-        store.commit('setBackend', 'CLOUD')
-        expect(store.getters['backend']).toEqual('CLOUD')
-        expect(localStorage.getItem('backend')).toEqual('CLOUD')
-        store.commit('unsetBackend')
-        expect(store.getters['backend']).toBe(null)
-        expect(localStorage.getItem('backend')).toBe(null)
-      })
     })
 
     describe('setConnected', () => {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
I believe this is all we should need to solve #614. By not saving the backend choice in localstorage (relying instead on the `VUE_APP_BACKEND` var), if a user without cloud switches the toggle they won't be forever stuck in a redirect to universal.prefect.io