### PR TITLE
Fix some issues with checking auth when returning to the application

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -191,6 +191,7 @@ export default {
     isAuthorized(value) {
       if (value) {
         this.getApi()
+        this.getTenants()
       }
     }
   },

--- a/src/main.js
+++ b/src/main.js
@@ -364,16 +364,15 @@ const handleVisibilityChange = () => {
 
   if (!document[hidden]) {
     if (
-      store.getters['auth/isAuthorized'] &&
-      now >= authorizationExpiration &&
-      now < authenticationExpiration
-    ) {
-      store.dispatch('auth/authorize')
-    } else if (
-      store.getters['auth/isAuthenticatd'] &&
+      !store.getters['auth/isAuthenticated'] ||
       now >= authenticationExpiration
     ) {
       store.dispatch('auth/authenticate')
+    } else if (
+      !store.getters['auth/isAuthorized'] ||
+      now >= authorizationExpiration
+    ) {
+      store.dispatch('auth/authorize')
     }
   }
 }

--- a/src/store/auth/index.js
+++ b/src/store/auth/index.js
@@ -22,7 +22,7 @@ const state = {
 
 const getters = {
   isAuthenticated(state) {
-    return !!state.isAuthenticated
+    return !!state.isAuthenticated && new Date().getTime() < state.idTokenExpiry
   },
   isAuthorized(state) {
     return (

--- a/src/workers/token.worker.js
+++ b/src/workers/token.worker.js
@@ -284,7 +284,6 @@ const connect = c => {
     // If a logout signal is sent, unset the tokens on the worker state and
     // publish the logout event to all connections
     if (type == 'logout') {
-      console.log('handling logout')
       state.authenticationTokens = null
       state.authorizationTokens = null
       postToConnections({ type: 'logout' })


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR fixes the ordering of some auth checks when returning to the application and attempts to address some issues where tenants weren't being fetched after the apollo cache had been cleared and no navigation had taken place.