### PR TITLE
Gracefully handle null default tenants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 ### Bugfixes
 
 - Fix issue with Server check on startup - [#788](https://github.com/PrefectHQ/ui/pull/788)
+- Fix issue with User API Keys screen and no default tenants on keys - [#802](https://github.com/PrefectHQ/ui/pull/802)
 
 ## 2021-04-21
 

--- a/src/pages/UserSettings/APIKeys.vue
+++ b/src/pages/UserSettings/APIKeys.vue
@@ -168,7 +168,7 @@ export default {
               name: key.name,
               created_at: key.created,
               expires: key.expires_at,
-              tenant: defaultTenant.name,
+              tenant: defaultTenant?.name,
               user_id: key.user_id
             }
           })


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR gracefully handles the situation where an API key has no default tenant associated with it; at this moment in time, this isn't truly possible but it may be in the near future.  Without these changes, the API Keys screen fails to load whenever the user has keys with no default tenants.