### PR TITLE
don't disable context and environment key field

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,10 +4,11 @@
 
 ### Features and Improvements
 
-- Fix the issue where the key fields for the context and environment are disabled after typing on the run page - [#810](https://github.com/PrefectHQ/ui/pull/810)
+- None
 
 ### Bugfixes
 
+- Fix the issue where the key fields for the context and environment are disabled after typing on the run page - [#810](https://github.com/PrefectHQ/ui/pull/810)
 - Populate JSON editor with only checked parameters - [#787](https://github.com/PrefectHQ/ui/pull/787)
 
 ## 2021-05-04

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Fix the issue where the key fields for the context and environment are disabled after typing on the run page - [#810](https://github.com/PrefectHQ/ui/pull/810)
 
 ### Bugfixes
 

--- a/src/components/CustomInputs/DictInput.vue
+++ b/src/components/CustomInputs/DictInput.vue
@@ -276,10 +276,7 @@ export default {
               outlined
               dense
               :placeholder="keyLabel"
-              :readonly="
-                disabledKeys.includes(keys[i]) ||
-                  Object.keys(JSON.parse(jsonInput)).includes(keys[i])
-              "
+              :readonly="disabledKeys.includes(keys[i])"
               @keyup="_handleKeypress"
             />
           </v-col>


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This should fix the issue where the key fields for the context and environment are disabled after typing on the run page
