### PR TITLE
Add recently updated flow tile

### DIFF
--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -14,6 +14,7 @@ import SummaryTile from '@/pages/Dashboard/Summary-Tile'
 import UpcomingRunsTile from '@/pages/Dashboard/UpcomingRuns-Tile'
 import UpgradeUsageTile from '@/pages/Dashboard/UsageTiles/UpgradeUsage-Tile'
 import SubPageNav from '@/layouts/SubPageNav'
+import FlowRecentUpdate from '@/pages/Dashboard/FlowRecentUpdate'
 import { mapGetters, mapActions } from 'vuex'
 import gql from 'graphql-tag'
 
@@ -57,6 +58,7 @@ export default {
     AgentsTile,
     BreadCrumbs,
     FailedFlowsTile,
+    FlowRecentUpdate,
     FlowTableTile,
     InProgressTile,
     NavTabBar,
@@ -105,7 +107,8 @@ export default {
       numberOfTiles: 10,
       projectId: this.$route.params.id,
       refreshTimeout: null,
-      tab: this.getTab()
+      tab: this.getTab(),
+      recentlyUpdatedFlow: null
     }
   },
   computed: {
@@ -292,6 +295,14 @@ export default {
         reverse-transition="tab-fade"
       >
         <div class="tile-grid my-4">
+          <div
+            v-show="!!recentlyUpdatedFlow"
+            class="tile-container span-full span-row-1"
+          >
+            <FlowRecentUpdate
+              @recentlyUpdatedFlow="recentlyUpdatedFlow = $event"
+            />
+          </div>
           <v-skeleton-loader
             :loading="loadedTiles < 7"
             type="image"
@@ -441,7 +452,7 @@ export default {
 
 <style lang="scss" scoped>
 $cellsize: 412px;
-$rowsize: 153px;
+$rowsize: 1px;
 $guttersize: 24px;
 $spans: 1, 2, 3, 4, 5, 6;
 

--- a/src/pages/Dashboard/FlowRecentUpdate.vue
+++ b/src/pages/Dashboard/FlowRecentUpdate.vue
@@ -1,0 +1,116 @@
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  data() {
+    return {
+      recentlyUpdatedFlow: null,
+      loading: 0,
+      fiveMinutesAgoIsoString: new Date().toISOString()
+    }
+  },
+  created() {
+    this.computeFiveMinutesAgoIsoString()
+  },
+  computed: {
+    ...mapGetters('api', ['isCloud']),
+    ...mapGetters('tenant', ['tenant']),
+    ...mapGetters('user', ['user']),
+    minutesSinceUpdateText() {
+      if (this.recentlyUpdatedFlow === undefined) {
+        return ''
+      }
+      const diffMins = Math.floor(
+        ((new Date() -
+          (new Date(this.recentlyUpdatedFlow.updated) % 86400000)) %
+          3600000) /
+          60000
+      )
+      if (diffMins === 0) {
+        return 'less than a minute ago'
+      }
+      return diffMins.toString() + ' minutes ago'
+    }
+  },
+  methods: {
+    computeFiveMinutesAgoIsoString() {
+      var fiveMinutesAgo = new Date()
+      fiveMinutesAgo.setMinutes(fiveMinutesAgo.getMinutes() - 5)
+      this.fiveMinutesAgoIsoString = fiveMinutesAgo.toISOString()
+    }
+  },
+  apollo: {
+    recentlyUpdatedFlow: {
+      query() {
+        return require('@/graphql/Dashboard/flows.js').default(this.isCloud)
+      },
+      variables() {
+        let sortBy = {
+          updated: 'desc'
+        }
+
+        let searchParams = [
+          { archived: { _eq: false } },
+          { updated: { _gte: this.fiveMinutesAgoIsoString } }
+        ]
+
+        if (this.isCloud) {
+          searchParams.push({ created_by_user_id: { _eq: this.user.id } })
+        }
+
+        return {
+          limit: 1,
+          orderBy: sortBy,
+          searchParams: {
+            _and: [...searchParams]
+          }
+        }
+      },
+      loadingKey: 'loading',
+      pollInterval: 1000,
+      update(data) {
+        this.computeFiveMinutesAgoIsoString()
+        this.$emit('recentlyUpdatedFlow', data?.flow[0])
+        return data?.flow[0]
+      }
+    }
+  }
+}
+</script>
+
+<template>
+  <v-card v-if="!!recentlyUpdatedFlow" class="pa-4">
+    Flow
+    <span class="flow-name"> {{ recentlyUpdatedFlow.name }} </span>
+    in project
+    <span class="project-name"> {{ recentlyUpdatedFlow.project.name }} </span>
+    was updated
+    {{ minutesSinceUpdateText }}
+    <router-link
+      class="v-btn float-right medium"
+      :data-cy="
+        'flow-link|' +
+          recentlyUpdatedFlow.name +
+          '|' +
+          (recentlyUpdatedFlow.archived ? 'archived' : 'active') +
+          '-' +
+          recentlyUpdatedFlow.version
+      "
+      :to="{
+        name: 'flow',
+        params: { id: recentlyUpdatedFlow.flow_group.id, tenant: tenant.slug }
+      }"
+    >
+      Go to flow
+    </router-link>
+  </v-card>
+</template>
+
+<style lang="scss" scoped>
+.flow-name {
+  font-weight: bold;
+}
+.project-name {
+  font-weight: bold;
+}
+</style>


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR

Draft PR for feedback on recently updated flow notification tile. 

A couple things I had trouble with and I'm not sure if I've found the right solution:

1. Hiding the tile correctly (for spacing purposes) if no recent flows are found. Emitting the property from `FlowRecentUpdate` to  `Dashboard` seems to be the best way to do this

2. Updating variables dynamically on queries. Apollo doesn't understand that dates will change between queries, so variables won't be refreshed without some workarounds. The current workaround is to update a property used in query variables during the `update` callback.


Preview:

![image](https://user-images.githubusercontent.com/42625717/117545993-34f1a780-aff6-11eb-82f2-f65a20f9dd23.png)
