### PR TITLE
Stop json param value flicker

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Beautify json and add json type to default parameters json edit option to stop value flicker - [#837](https://github.com/PrefectHQ/ui/pull/837)
 
 ## 2021-05-14
 

--- a/src/pages/Flow/Settings/DefaultParameters.vue
+++ b/src/pages/Flow/Settings/DefaultParameters.vue
@@ -3,6 +3,7 @@ import { parametersMixin } from '@/mixins/parametersMixin.js'
 import CardTitle from '@/components/Card-Title'
 import ParametersForm from '@/components/ParametersForm'
 import JsonInput from '@/components/CustomInputs/JsonInput'
+import jsBeautify from 'js-beautify'
 
 export default {
   components: { JsonInput, CardTitle, ParametersForm },
@@ -47,6 +48,24 @@ export default {
         return a.name > b.name ? 1 : -1
       })
       return sorted
+    }
+  },
+  watch: {
+    editAll(val) {
+      // Allows swapping to jsonInput
+      if (val) {
+        this.parameterInput = jsBeautify(this.parameterInput, {
+          indent_size: 4,
+          space_in_empty_paren: true,
+          preserve_newlines: true,
+          indent_empty_lines: true
+        })
+
+        // Use next tick to make sure the json input element exists
+        this.$nextTick(() => {
+          this.$refs['parameterRef'].validateJson()
+        })
+      }
     }
   },
   methods: {
@@ -185,6 +204,7 @@ export default {
                     <JsonInput
                       ref="parameterRef"
                       v-model="parameterInput"
+                      selected-type="json"
                       :new-parameter-input="newParameterInput"
                       :disabled="selectedFlow.archived"
                       data-cy="flow-group-parameter-input"


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
- I can't actually replicate the issue raised in #836 but believe this should fix it.  (It also removes an issue where values shown do not update in the json on save and where the value alters on the first click of format.)
- Closes #836 