### PR TITLE
Improve usability of the quick run button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -463,7 +463,7 @@ export default {
     </v-main>
 
     <Alert
-      v-if="false && getAlert.alertShow"
+      v-if="getAlert.alertShow"
       v-model="getAlert.alertShow"
       :type="getAlert.alertType"
       :message="getAlert.alertMessage"

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import GlobalSearch from '@/components/GlobalSearchBar/GlobalSearch'
 import TeamSideNav from '@/components/Nav/TeamSideNav'
 import { eventsMixin } from '@/mixins/eventsMixin'
 import debounce from 'lodash.debounce'
+import VSnackbars from '@/components/Snackbars/Snackbars'
 
 const SERVER_KEY = `${process.env.VUE_APP_RELEASE_TIMESTAMP}_server_url`
 
@@ -44,7 +45,8 @@ export default {
     ApplicationNavBar,
     Footer,
     GlobalSearch,
-    TeamSideNav
+    TeamSideNav,
+    VSnackbars
   },
   mixins: [eventsMixin],
   data() {
@@ -454,7 +456,7 @@ export default {
     </v-main>
 
     <Alert
-      v-if="getAlert.alertShow"
+      v-if="false && getAlert.alertShow"
       v-model="getAlert.alertShow"
       :type="getAlert.alertType"
       :message="getAlert.alertMessage"
@@ -462,6 +464,8 @@ export default {
       :link-text="getAlert.linkText"
       :timeout="12000"
     />
+
+    <VSnackbars />
   </v-app>
 </template>
 

--- a/src/components/Snackbars/Snackbars.vue
+++ b/src/components/Snackbars/Snackbars.vue
@@ -1,0 +1,74 @@
+<script>
+import { mapGetters, mapMutations } from 'vuex'
+export default {
+  computed: {
+    ...mapGetters('alert', ['notifications']),
+    list() {
+      return this.notifications
+    }
+  },
+  methods: {
+    ...mapMutations('alert', ['dismiss'])
+  }
+}
+</script>
+
+<template>
+  <transition-group
+    class="alerts-drawer-wrapper justify-end d-flex flex-column align-end"
+    name="alerts-drawer-wrapper"
+    tag="div"
+  >
+    <template v-for="alert in list">
+      <v-card
+        :key="alert.id"
+        class="alerts-snack rounded-sm elevation-4 mr-4 mb-4"
+        max-width="500px"
+        :min-width="$vuetify.breakpoint.xsOnly ? '80%' : '350px'"
+        :color="alert.color"
+      >
+        <v-card-actions class="pl-4 pr-1">
+          <span
+            class="grey--text text--lighten-3 text-body-1"
+            v-text="alert.text"
+          />
+          <v-spacer />
+          <v-btn
+            color="grey lighten-3"
+            class="ml-2"
+            icon
+            @click="dismiss(alert)"
+          >
+            <v-icon>close</v-icon>
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </template>
+  </transition-group>
+</template>
+
+<style lang="scss" scoped>
+.alerts-drawer-wrapper {
+  height: 100vh;
+  pointer-events: none;
+  position: fixed;
+  width: 100%;
+  z-index: 1000;
+
+  .alerts-snack {
+    pointer-events: auto;
+    transition: all 0.5s;
+  }
+
+  &-enter,
+  &-leave-to,
+  &-leave-active {
+    opacity: 0;
+    transform: translateY(-30px);
+  }
+
+  &-leave-active {
+    position: absolute;
+  }
+}
+</style>

--- a/src/graphql/Flow/flow-run-by-pk.gql
+++ b/src/graphql/Flow/flow-run-by-pk.gql
@@ -1,0 +1,6 @@
+query FlowRunByPK($id: uuid!) {
+  flow_run_by_pk(id: $id) {
+    id
+    name
+  }
+}

--- a/src/pages/Flow/Actions.vue
+++ b/src/pages/Flow/Actions.vue
@@ -85,7 +85,11 @@ export default {
     }
   },
   methods: {
-    ...mapActions('alert', ['setAlert']),
+    ...mapActions('alert', [
+      'setAlert',
+      'addNotification',
+      'updateNotification'
+    ]),
     _changeVersion(val) {
       if (val) {
         let query = { ...this.$route.query, version: val }
@@ -109,6 +113,13 @@ export default {
     },
     async quickRunFlow() {
       this.isRunning = true
+      const notificationId = await this.addNotification({
+        color: 'primaryLight',
+        loading: true,
+        text: 'Creating run...',
+        dismissable: false
+      })
+
       try {
         const { data, errors } = await this.$apollo.mutate({
           mutation: require('@/graphql/Mutations/create-flow-run.gql'),
@@ -117,53 +128,57 @@ export default {
           },
           errorPolicy: 'all'
         })
+
+        if (errors) throw new Error(errors?.[0]?.message)
+
+        this.isRunning = false
+
         if (data?.create_flow_run?.id) {
-          // this.$router.push({
-          //   name: 'flow-run',
-          //   params: { id: data?.create_flow_run?.id, tenant: this.tenant?.slug }
-          // })
-          this.setAlert({
-            alertShow: true,
-            alertMessage: 'Run created.',
-            alertType: 'info',
-            alertLink: {
-              name: 'flow-run',
-              params: { id: data.create_flow_run.id, tenant: this.tenant?.slug }
+          const run = await this.$apollo.query({
+            query: require('@/graphql/Flow/flow-run-by-pk.gql'),
+            variables: {
+              id: data.create_flow_run.id
+            },
+            errorPolicy: 'all'
+          })
+
+          await this.updateNotification({
+            id: notificationId,
+            notification: {
+              color: 'primary',
+              loading: false,
+              linkText: 'Visit',
+              to: {
+                name: 'flow-run',
+                params: {
+                  id: data.create_flow_run.id,
+                  tenant: this.tenant?.slug
+                }
+              },
+              text: 'Run created!',
+              subtext: run?.data?.flow_run_by_pk?.name,
+              dismissable: true,
+              timeout: 20000
             }
           })
         }
-        if (errors) {
-          this.quickRunErrorAlert(errors[0]?.message)
-        }
       } catch (err) {
-        this.quickRunErrorAlert()
+        await this.updateNotification({
+          id: notificationId,
+          notification: {
+            color: 'error',
+            loading: false,
+            text: 'There was a problem creating your run',
+            subtext: err?.message?.includes('archived')
+              ? 'This flow version is archived - you likely have a newer version of your flow'
+              : 'Error',
+            dismissable: true,
+            timeout: 10000
+          }
+        })
         LogRocket.captureException(err)
       }
       this.isRunning = false
-    },
-    quickRunErrorAlert(err) {
-      if (err && err?.includes('archived')) {
-        this.alertShow = true
-        this.alertMessage =
-          'This flow version is now archived.  You have a newer version of your flow.'
-        this.alertLink = {
-          name: 'flow',
-          params: { id: this.flow.id, tenant: this.tenant?.slug },
-          query: { versions: '' }
-        }
-        this.alertType = 'error'
-      } else {
-        this.alertShow = true
-        this.alertMessage = 'There was a problem running your flow'
-        this.alertType = 'error'
-      }
-
-      this.setAlert({
-        alertShow: this.alertShow,
-        alertMessage: this.alertMessage,
-        alertType: this.alertType,
-        alertLink: this.alertLink
-      })
     },
     async scheduleFlow() {
       this.scheduleLoading = true

--- a/src/pages/Flow/Actions.vue
+++ b/src/pages/Flow/Actions.vue
@@ -118,9 +118,18 @@ export default {
           errorPolicy: 'all'
         })
         if (data?.create_flow_run?.id) {
-          this.$router.push({
-            name: 'flow-run',
-            params: { id: data?.create_flow_run?.id, tenant: this.tenant?.slug }
+          // this.$router.push({
+          //   name: 'flow-run',
+          //   params: { id: data?.create_flow_run?.id, tenant: this.tenant?.slug }
+          // })
+          this.setAlert({
+            alertShow: true,
+            alertMessage: 'Run created.',
+            alertType: 'info',
+            alertLink: {
+              name: 'flow-run',
+              params: { id: data.create_flow_run.id, tenant: this.tenant?.slug }
+            }
           })
         }
         if (errors) {

--- a/src/store/alert/index.js
+++ b/src/store/alert/index.js
@@ -5,12 +5,20 @@ const state = {
     alertType: null,
     alertLink: null,
     linkText: ''
-  }
+  },
+  notifications: [
+    { id: 1, text: 'foo' },
+    { id: 2, text: 'bar' },
+    { id: 3, text: 'batz' }
+  ]
 }
 
 const getters = {
   getAlert(state) {
     return state.alert
+  },
+  notifications(state) {
+    return state.notifications
   }
 }
 
@@ -26,6 +34,12 @@ const mutations = {
       alertLink: null,
       linkText: ''
     }
+  },
+  dismiss(state, notification) {
+    const index = state.notifications.indexOf(
+      n => n.text == notification.text && notification.id === n.id
+    )
+    state.notifications.splice(index, 1)
   }
 }
 

--- a/src/store/alert/index.js
+++ b/src/store/alert/index.js
@@ -41,6 +41,7 @@ const mutations = {
     state.notifications = notifications
   },
   setNotificationTimeout(state, { id, timeoutId }) {
+    clearTimeout(state['notificationTimeouts'][id])
     state.notificationTimeouts[id] = timeoutId
   }
 }
@@ -90,8 +91,6 @@ const actions = {
       commit('setNotifications', notifications)
 
       if (notification.timeout) {
-        clearTimeout(getters['notificationTimeouts'][notification.id])
-
         const timeoutId = setTimeout(() => {
           dispatch('dismissNotification', { id })
         }, notification.timeout)

--- a/tests/unit/store/alert.spec.js
+++ b/tests/unit/store/alert.spec.js
@@ -6,60 +6,14 @@ jest.mock('@/main', () => {
   }
 })
 
+import Vuex from 'vuex'
+import alert from '@/store/alert'
 import store from '@/store'
 jest.useFakeTimers()
 
 describe('Alert Vuex Module', () => {
-  it('should initially have a show key that is false and other keys should be falsey', () => {
-    expect(store.getters['alert/getAlert']).toStrictEqual({
-      alertShow: false,
-      alertMessage: '',
-      alertType: null,
-      alertLink: null,
-      linkText: ''
-    })
-  })
-
-  describe('mutations', () => {
-    it('updates the state when setAl is called', () => {
-      expect(store.getters['alert/getAlert']).toStrictEqual({
-        alertShow: false,
-        alertMessage: '',
-        alertType: null,
-        alertLink: null,
-        linkText: ''
-      })
-      store.commit('alert/setAl', {
-        alertShow: true,
-        alertMessage: 'Testing testing 123',
-        alertType: 'error',
-        alertLink: null,
-        linkText: ''
-      })
-      expect(store.getters['alert/getAlert']).toStrictEqual({
-        alertShow: true,
-        alertMessage: 'Testing testing 123',
-        alertType: 'error',
-        alertLink: null,
-        linkText: ''
-      })
-    })
-    it('empties the state when setEmpty is called', () => {
-      store.commit('alert/setAl', {
-        alertShow: true,
-        alertMessage: 'Testing testing 123',
-        alertType: 'error',
-        alertLink: null,
-        linkText: ''
-      })
-      expect(store.getters['alert/getAlert']).toStrictEqual({
-        alertShow: true,
-        alertMessage: 'Testing testing 123',
-        alertType: 'error',
-        alertLink: null,
-        linkText: ''
-      })
-      store.commit('alert/setEmpty')
+  describe('Global Alert', () => {
+    it('should initially have a show key that is false and other keys should be falsey', () => {
       expect(store.getters['alert/getAlert']).toStrictEqual({
         alertShow: false,
         alertMessage: '',
@@ -68,30 +22,114 @@ describe('Alert Vuex Module', () => {
         linkText: ''
       })
     })
+
+    describe('mutations', () => {
+      it('updates the state when setAl is called', () => {
+        expect(store.getters['alert/getAlert']).toStrictEqual({
+          alertShow: false,
+          alertMessage: '',
+          alertType: null,
+          alertLink: null,
+          linkText: ''
+        })
+        store.commit('alert/setAl', {
+          alertShow: true,
+          alertMessage: 'Testing testing 123',
+          alertType: 'error',
+          alertLink: null,
+          linkText: ''
+        })
+        expect(store.getters['alert/getAlert']).toStrictEqual({
+          alertShow: true,
+          alertMessage: 'Testing testing 123',
+          alertType: 'error',
+          alertLink: null,
+          linkText: ''
+        })
+      })
+      it('empties the state when setEmpty is called', () => {
+        store.commit('alert/setAl', {
+          alertShow: true,
+          alertMessage: 'Testing testing 123',
+          alertType: 'error',
+          alertLink: null,
+          linkText: ''
+        })
+        expect(store.getters['alert/getAlert']).toStrictEqual({
+          alertShow: true,
+          alertMessage: 'Testing testing 123',
+          alertType: 'error',
+          alertLink: null,
+          linkText: ''
+        })
+        store.commit('alert/setEmpty')
+        expect(store.getters['alert/getAlert']).toStrictEqual({
+          alertShow: false,
+          alertMessage: '',
+          alertType: null,
+          alertLink: null,
+          linkText: ''
+        })
+      })
+    })
+
+    describe('actions', () => {
+      test('setAlert sets the new alert state, calls setTimeout and then empties the alert state', async () => {
+        await store.dispatch('alert/setAlert', {
+          alertShow: true,
+          alertMessage: 'Testing testing 234',
+          alertType: 'error',
+          alertLink: null,
+          linkText: ''
+        })
+        expect(store.getters['alert/getAlert']).toStrictEqual({
+          alertShow: true,
+          alertMessage: 'Testing testing 234',
+          alertType: 'error',
+          alertLink: null,
+          linkText: ''
+        })
+        expect(setTimeout).toHaveBeenCalledTimes(1)
+        expect(setTimeout).toHaveBeenLastCalledWith(
+          expect.any(Function),
+          6000,
+          'setEmpty'
+        )
+      })
+    })
   })
 
-  describe('actions', () => {
-    test('setAlert sets the new alert state, calls setTimeout and then empties the alert state', async () => {
-      await store.dispatch('alert/setAlert', {
-        alertShow: true,
-        alertMessage: 'Testing testing 234',
-        alertType: 'error',
-        alertLink: null,
-        linkText: ''
+  describe('Notifications', () => {
+    describe('getters', () => {
+      it('should return notifications', () => {
+        const notifications = ['foo', 'bar', 'batz']
+
+        const store = new Vuex.Store({
+          state: { ...alert.state, notifications: [...notifications] },
+          getters: alert.getters
+        })
+
+        expect(store.getters.notifications).toStrictEqual(notifications)
       })
-      expect(store.getters['alert/getAlert']).toStrictEqual({
-        alertShow: true,
-        alertMessage: 'Testing testing 234',
-        alertType: 'error',
-        alertLink: null,
-        linkText: ''
+
+      it('should return notificationTimeouts', () => {
+        const notificationTimeouts = { 0: 123, 1: 456 }
+
+        const store = new Vuex.Store({
+          state: {
+            ...alert.state,
+            notificationTimeouts: Object.assign({}, notificationTimeouts)
+          },
+          getters: alert.getters
+        })
+
+        expect(store.getters.notificationTimeouts).toStrictEqual(
+          notificationTimeouts
+        )
       })
-      expect(setTimeout).toHaveBeenCalledTimes(1)
-      expect(setTimeout).toHaveBeenLastCalledWith(
-        expect.any(Function),
-        6000,
-        'setEmpty'
-      )
     })
+
+    describe('mutations', () => {})
+    describe('actions', () => {})
   })
 })

--- a/tests/unit/store/alert.spec.js
+++ b/tests/unit/store/alert.spec.js
@@ -6,10 +6,19 @@ jest.mock('@/main', () => {
   }
 })
 
+import uniqueId from 'lodash.uniqueid'
+jest.mock('lodash.uniqueid')
+
 import Vuex from 'vuex'
 import alert from '@/store/alert'
 import store from '@/store'
+
 jest.useFakeTimers()
+
+const initialState = { ...alert.state }
+const getInitialState = () => {
+  return { ...initialState }
+}
 
 describe('Alert Vuex Module', () => {
   describe('Global Alert', () => {
@@ -105,7 +114,7 @@ describe('Alert Vuex Module', () => {
         const notifications = ['foo', 'bar', 'batz']
 
         const store = new Vuex.Store({
-          state: { ...alert.state, notifications: [...notifications] },
+          state: { ...getInitialState(), notifications: [...notifications] },
           getters: alert.getters
         })
 
@@ -129,7 +138,152 @@ describe('Alert Vuex Module', () => {
       })
     })
 
-    describe('mutations', () => {})
-    describe('actions', () => {})
+    describe('mutations', () => {
+      let store
+
+      beforeEach(() => {
+        clearTimeout.mockClear()
+        store = new Vuex.Store({
+          state: getInitialState(),
+          getters: alert.getters,
+          actions: alert.actions,
+          mutations: alert.mutations
+        })
+      })
+
+      it('setNotifications correctly stores notifications', () => {
+        const notifications = ['lorem', 'ipsum']
+
+        store.commit('setNotifications', notifications)
+
+        expect(store.getters.notifications).toStrictEqual(notifications)
+      })
+
+      it('setNotificationTimeout clears any existing timeout and stores a new timeout id', () => {
+        const id = 'foo-bar'
+        const timeoutId = 123
+        const timeoutId2 = 456
+
+        store.commit('setNotificationTimeout', { id, timeoutId })
+
+        expect(store.getters.notificationTimeouts).toStrictEqual({
+          [id]: timeoutId
+        })
+
+        store.commit('setNotificationTimeout', { id, timeoutId: timeoutId2 })
+
+        expect(clearTimeout).toHaveBeenCalledWith(timeoutId)
+
+        expect(store.getters.notificationTimeouts).toStrictEqual({
+          [id]: timeoutId2
+        })
+      })
+    })
+
+    // addNotification
+    // dismissNotification
+    // updateNotification
+    describe('actions', () => {
+      let store
+      const storeClear = () => {
+        store = new Vuex.Store({
+          state: getInitialState(),
+          getters: alert.getters,
+          actions: alert.actions,
+          mutations: alert.mutations
+        })
+      }
+
+      describe('addNotification', () => {
+        beforeEach(storeClear)
+
+        it('returns sequential ids for each call', async () => {
+          let id
+
+          uniqueId
+            .mockReturnValueOnce(1)
+            .mockReturnValueOnce(2)
+            .mockReturnValueOnce(3)
+            .mockReturnValueOnce(4)
+
+          id = await store.dispatch('addNotification', { text: 'foo' })
+
+          expect(id).toStrictEqual(1)
+
+          id = await store.dispatch('addNotification', { text: 'bar' })
+
+          expect(id).toStrictEqual(2)
+
+          id = await store.dispatch('addNotification', { text: 'batz' })
+
+          expect(id).toStrictEqual(3)
+
+          id = await store.dispatch('addNotification', { text: 'fiz' })
+
+          expect(id).toStrictEqual(4)
+        })
+
+        it('adds the passed notification to the store', async () => {
+          const notification = { text: 'fix' }
+
+          expect(store.getters.notifications).toStrictEqual([])
+
+          const id = await store.dispatch('addNotification', notification)
+
+          expect(store.getters.notifications).toStrictEqual([
+            { id: id, ...notification }
+          ])
+        })
+
+        // TODO: Add tests for timeout logic
+      })
+
+      describe('dismissNotification', () => {
+        beforeEach(storeClear)
+
+        it('removes the notification with the passed id from the store', async () => {
+          const notification = { text: 'sabe' }
+
+          uniqueId.mockReturnValueOnce(1)
+
+          const id = await store.dispatch('addNotification', notification)
+
+          expect(id).toStrictEqual(1)
+
+          expect(store.getters.notifications).toStrictEqual([
+            { id, ...notification }
+          ])
+
+          await store.dispatch('dismissNotification', { id: 1 })
+
+          expect(store.getters.notifications).toStrictEqual([])
+        })
+      })
+
+      describe('updateNotification', () => {
+        beforeEach(storeClear)
+
+        it('updates the notification with the passed id with new data', async () => {
+          const notification = { text: 'sabe' }
+
+          uniqueId.mockReturnValueOnce(1)
+
+          const id = await store.dispatch('addNotification', notification)
+
+          expect(store.getters.notifications).toStrictEqual([
+            { id, ...notification }
+          ])
+
+          await store.dispatch('updateNotification', {
+            id: 1,
+            notification: { text: 'ebas' }
+          })
+
+          expect(store.getters.notifications[0].text).toStrictEqual('ebas')
+        })
+
+        // TODO: Add tests for timeout logic
+      })
+    })
   })
 })


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR removes the automatic routing of the quick run button and introduces a new toast system for stackable global toasts with a straightforward CRUD system. It should now be a lot easier to create a bunch of runs with default parameters!


https://user-images.githubusercontent.com/27291717/118725558-19f51380-b7fe-11eb-8692-6a220b90c261.mov

