### PR TITLE
Remove options button for server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,10 +9,9 @@
 
 ### Bugfixes
 
-<<<<<<< HEAD
 - Fix issues with pre-populating and resetting job templates and task definitions for run configs - [#839](https://github.com/PrefectHQ/ui/pull/839)
-=======
 - Check for the correct values when disabling next for the Pager Duty action - [#835](https://github.com/PrefectHQ/ui/pull/835)
+- Don't show work queue option in Server - []()
 
 ## 2021-05-17
 
@@ -20,7 +19,6 @@
 
 - Covert this.allowedUsers in the Members component to a computed property to use the nullish coalescing operator/check for total allowed users -[#841](https://github.com/PrefectHQ/ui/pull/841)
 - Beautify json and add json type to default parameters json edit option to stop value flicker - [#837](https://github.com/PrefectHQ/ui/pull/837)
->>>>>>> 7e68094dbf76510039632e0317a6d9c1ee435f8b
 
 ## 2021-05-14
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@
 
 - Fix issues with pre-populating and resetting job templates and task definitions for run configs - [#839](https://github.com/PrefectHQ/ui/pull/839)
 - Check for the correct values when disabling next for the Pager Duty action - [#835](https://github.com/PrefectHQ/ui/pull/835)
-- Don't show work queue option in Server - []()
+- Don't show work queue option in Server - [#848](https://github.com/PrefectHQ/ui/pull/848)
 
 ## 2021-05-17
 

--- a/src/pages/Dashboard/UpcomingRuns-Tile.vue
+++ b/src/pages/Dashboard/UpcomingRuns-Tile.vue
@@ -460,7 +460,7 @@ export default {
       </v-btn>
 
       <v-btn
-        v-if="!overlay"
+        v-if="!overlay && isCloud"
         small
         depressed
         color="primary"


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Hides the upcoming runs tile options button for server (since the routes don't exist there)