### PR TITLE
Remove fetchpolicy on tenant settings mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Remove bad fetchPolicy on tenant settings mutation - [#858](https://github.com/PrefectHQ/ui/pull/858)
 
 ## 2021-05-24
 

--- a/src/store/tenant/index.js
+++ b/src/store/tenant/index.js
@@ -191,8 +191,7 @@ const actions = {
         },
         error(error) {
           throw error
-        },
-        fetchPolicy: 'network-only'
+        }
       })
       await dispatch('getTenants')
     } catch (e) {


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
The update tenant settings mutation had a fetchPolicy of `network-only` - this generated an error because mutations can only have fetch policies of `no-cache`. 