### PR TITLE
Depressed prop on upgrade badge

### DIFF
--- a/src/components/Nav/TeamMenu.vue
+++ b/src/components/Nav/TeamMenu.vue
@@ -145,6 +145,7 @@ export default {
               >Roles
               <UpgradeBadge
                 v-if="isCloud && !hasPermission('feature', 'custom-role')"
+                depressed
                 inline
               >
                 <span class="font-weight-medium">Custom Roles</span> are only

--- a/src/components/UpgradeBadge.vue
+++ b/src/components/UpgradeBadge.vue
@@ -10,9 +10,9 @@ export default {
       default: false,
       required: false
     },
-    elevate: {
+    depressed: {
       type: Boolean,
-      default: true,
+      default: false,
       required: false
     }
   }
@@ -34,7 +34,7 @@ export default {
           origin="center"
           :inline="inline"
           class="pa-0 upgrade-badge"
-          :class="{ elevate: elevate }"
+          :class="{ elevate: !depressed }"
         >
           <template #badge>
             <div class="white--text d-flex align-center justify-center px-1">

--- a/src/components/UpgradeBadge.vue
+++ b/src/components/UpgradeBadge.vue
@@ -9,6 +9,11 @@ export default {
       type: Boolean,
       default: false,
       required: false
+    },
+    elevate: {
+      type: Boolean,
+      default: true,
+      required: false
     }
   }
 }
@@ -29,6 +34,7 @@ export default {
           origin="center"
           :inline="inline"
           class="pa-0 upgrade-badge"
+          :class="{ elevate: elevate }"
         >
           <template #badge>
             <div class="white--text d-flex align-center justify-center px-1">
@@ -56,10 +62,15 @@ export default {
 
 <style lang="scss">
 .upgrade-badge {
+  &.elevate {
+    .v-badge__badge {
+      box-shadow: 0px 2px 4px -1px rgb(0 0 0 / 20%),
+        0px 4px 5px 0px rgb(0 0 0 / 14%), 0px 1px 10px 0px rgb(0 0 0 / 12%) !important;
+    }
+  }
+
   /* stylelint-disable */
   .v-badge__badge {
-    box-shadow: 0px 2px 4px -1px rgb(0 0 0 / 20%),
-      0px 4px 5px 0px rgb(0 0 0 / 14%), 0px 1px 10px 0px rgb(0 0 0 / 12%) !important;
     left: unset;
     max-width: 31px;
     right: 0;

--- a/src/pages/TeamSettings/TeamSettings.vue
+++ b/src/pages/TeamSettings/TeamSettings.vue
@@ -212,6 +212,7 @@ export default {
               <UpgradeBadge
                 v-if="isCloud && !hasPermission('feature', 'custom-role')"
                 inline
+                depressed
               >
                 <span class="font-weight-medium">Custom Roles</span> are only
                 available on Enterprise plans.


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds a depressed prop to the upgrade badge (defaults to false) to let us use the badge is more places with better styling.

Before:
![Screen Shot 2021-06-23 at 11 32 46 AM](https://user-images.githubusercontent.com/27291717/123125717-c38b7e00-d416-11eb-9735-3533ae749dc0.png)

After:
![Screen Shot 2021-06-23 at 11 32 26 AM](https://user-images.githubusercontent.com/27291717/123125725-c5edd800-d416-11eb-8fd5-d7677cb8630b.png)
