### PR TITLE
schedule toggle 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## Unreleased
 
 ### Features and Improvements
@@ -9,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Disable schedule toggle only if a user does not have create or delete run permission - [#916](https://github.com/PrefectHQ/ui/pull/916)
 
 ## 2021-06-23
 

--- a/src/components/ScheduleToggle.vue
+++ b/src/components/ScheduleToggle.vue
@@ -25,8 +25,8 @@ export default {
       return this.flow.archived
     },
     disableToggle() {
-      const c = this.hasPermission('create', 'run')
-      const d = this.hasPermission('delete', 'run')
+      const c = !this.hasPermission('create', 'run')
+      const d = !this.hasPermission('delete', 'run')
       const scheduled = this.isScheduled
 
       return (c && d) || (!scheduled && c) || (scheduled && d)

--- a/src/pages/Flow/Actions.vue
+++ b/src/pages/Flow/Actions.vue
@@ -57,8 +57,8 @@ export default {
       }, true)
     },
     disableToggle() {
-      const c = this.hasPermission('create', 'run')
-      const d = this.hasPermission('delete', 'run')
+      const c = !this.hasPermission('create', 'run')
+      const d = !this.hasPermission('delete', 'run')
       const scheduled = this.isScheduled
 
       return (c && d) || (!scheduled && c) || (scheduled && d)


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Currently, the `disableToggle` check is returning true if a user has create or delete run permissions. This changes it to return true only if they don't have create or delete permissions.