### PR TITLE
Use role id instead of name in members page invite mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix membership invitation role selection - [#918](https://github.com/PrefectHQ/ui/pull/918)
 
 ## 2021-06-23a
 

--- a/src/pages/TeamSettings/Members.vue
+++ b/src/pages/TeamSettings/Members.vue
@@ -35,7 +35,7 @@ export default {
 
       // Inputs
       inviteEmailInput: null,
-      roleInput: 'TENANT_ADMIN',
+      roleInput: null,
       searchInput: '',
 
       // Forms
@@ -216,7 +216,7 @@ export default {
       this.$nextTick(() => {
         this.inviteEmailInput = null
         this.inviteError = null
-        this.roleInput = 'TENANT_ADMIN'
+        this.roleInput = this.roles.find(r => r.name == 'TENANT_ADMIN').id
       })
     }
   },
@@ -228,7 +228,11 @@ export default {
         return {}
       },
       pollInterval: 10000,
-      update: data => data.auth_role || []
+      update(data) {
+        if (!data) return
+        this.roleInput = data.auth_role?.find(r => r.name == 'TENANT_ADMIN').id
+        return data.auth_role
+      }
     }
   }
 }


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fix an issue where we were passing a role name instead of id in the `role_id` slot of the `create_membership_invitation` mutation.