### PR TITLE
Add current tenant name to account header if no account_name is found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Show current team name on account page if no account name is found - [#923](https://github.com/PrefectHQ/ui/pull/923)
 
 ### Bugfixes
 

--- a/src/pages/Admin/Admin.vue
+++ b/src/pages/Admin/Admin.vue
@@ -22,7 +22,8 @@ export default {
     pageTitle() {
       const pageTitles = {
         '/admin/teams/new': 'New team',
-        '/admin/account': this.license?.account_name || 'Account',
+        '/admin/account':
+          this.license?.account_name || this.tenant?.name || 'Account',
         '/admin/teams': `${
           this.license?.account_name ? this.license.account_name + ' ' : ''
         }Teams <span class="font-weight-light text-h6">(${


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds the current tenant name to the title of the admin account page when no account name exists on the license.

cc @ThatGalNatalie since you brought this up in your review 