### PR TITLE
fix: IndentationError in cloud tutorial

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Add missing indentation to the tutorial code sample -  [#924](https://github.com/PrefectHQ/ui/pull/924)
 
 ## 2021-06-24
 

--- a/src/pages/Tutorials/Markdown/Universal-Deploy.md
+++ b/src/pages/Tutorials/Markdown/Universal-Deploy.md
@@ -21,8 +21,8 @@ from prefect import task, Flow
 
 @task
 def hello_task():
-logger = prefect.context.get("logger")
-logger.info("Hello world!")
+    logger = prefect.context.get("logger")
+    logger.info("Hello world!")
 
 flow = Flow("hello-flow", tasks=[hello_task])
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR

### Add missing indentation in the tutorial code sample
 
The code miss indentation in line 6-7, so it would be an `IndentationError` when people simply copy, paste and execute the code from the tutorial. 

With the fix, they should be able to successfully execute it in one shot.  

<img width="1111" alt="Screen Shot 2021-06-25 at 8 20 13 PM" src="https://user-images.githubusercontent.com/8368609/123423945-c216ad00-d5f2-11eb-9f03-62444836382d.png">

###  No  test added 

Reason:  It's just simple doc format fix. 