### PR TITLE
Enable the quick run button for flows with required parameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Should include a fix for [#929](https://github.com/PrefectHQ/ui/issues/929), [#928](https://github.com/PrefectHQ/ui/issues/928), [#885](https://github.com/PrefectHQ/ui/issues/885), and [#813](https://github.com/PrefectHQ/ui/issues/813) - [#922](https://github.com/PrefectHQ/ui/pull/922)
 - Fix role highlight in dark mode - [#925](https://github.com/PrefectHQ/ui/pull/925)
 - Fix indentation error in doc code snippet - [#932](https://github.com/PrefectHQ/ui/pull/932)
+- Enables the quick run button for flows with required parameters with defaults on the flow object and not the flow group object - [#935](https://github.com/PrefectHQ/ui/pull/935)
 
 ## 2021-06-24
 

--- a/src/pages/Flow/Actions.vue
+++ b/src/pages/Flow/Actions.vue
@@ -51,7 +51,14 @@ export default {
 
       return this.flow.parameters.reduce((result, param) => {
         const parameterKey = param.name
-        if (param.required && !this.flowGroup.default_parameters[parameterKey])
+        // If the param is required and has no default set on the
+        // flow or the flow group, we return that for the reducer
+        // result
+        if (
+          param.required &&
+          !this.flowGroup.default_parameters[parameterKey] &&
+          !param.default
+        )
           return false
         return result
       }, true)


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Enables the quick run button for flows with required parameters with defaults on the flow object and not the flow group object