### PR TITLE
Improve type handling when passing parameters to create flow run mutation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Should include a fix for [#929](https://github.com/PrefectHQ/ui/issues/929), [#928](https://github.com/PrefectHQ/ui/issues/928), [#885](https://github.com/PrefectHQ/ui/issues/885), and [#813](https://github.com/PrefectHQ/ui/issues/813) - [#922](https://github.com/PrefectHQ/ui/pull/922)
 - Fix role highlight in dark mode - [#925](https://github.com/PrefectHQ/ui/pull/925)
 - Fix indentation error in doc code snippet - [#932](https://github.com/PrefectHQ/ui/pull/932)
+- Improve type handling when passing parameters to create flow run mutation - [#936](https://github.com/PrefectHQ/ui/pull/936)
 
 ## 2021-06-24
 

--- a/src/components/CustomInputs/DictInput.vue
+++ b/src/components/CustomInputs/DictInput.vue
@@ -75,7 +75,14 @@ export default {
           (this.json && Object.keys(JSON.parse(this.jsonInput)).includes(k)) ||
           (!this.json && this.includedKeys.includes(k))
         ) {
-          dict[k] = this.values[i]
+          try {
+            dict[k] =
+              typeof this.values[i] == 'string'
+                ? JSON.parse(this.values[i])
+                : this.values[i]
+          } catch {
+            dict[k] = this.values[i]
+          }
         }
       })
       return dict
@@ -104,6 +111,8 @@ export default {
           this.includedKeys = Object.keys(this.value)
         }
       }
+
+      this.$emit('toggle-json-editor', val)
     },
     includedKeys(val) {
       this.jsonInput = val.length > 0 ? JSON.stringify(this.value) : '{}'
@@ -182,6 +191,7 @@ export default {
           Object.fromEntries(v.map(entry => [entry.key, entry.value]))
         )
       } else {
+        // console.log()
         this.jsonInput = this.inputIsArray
           ? JSON.stringify(
               Object.fromEntries(
@@ -204,7 +214,11 @@ export default {
         : [null]
 
       this.values = this.inputIsArray
-        ? this.dict.map(entry => JSON.stringify(entry.value))
+        ? this.dict.map(entry =>
+            typeof entry.value == 'string'
+              ? entry.value
+              : JSON.stringify(entry.value)
+          )
         : this.dict
         ? Object.values(this.dict).map(value => JSON.stringify(value))
         : [null]

--- a/src/components/CustomInputs/DictInput.vue
+++ b/src/components/CustomInputs/DictInput.vue
@@ -191,7 +191,6 @@ export default {
           Object.fromEntries(v.map(entry => [entry.key, entry.value]))
         )
       } else {
-        // console.log()
         this.jsonInput = this.inputIsArray
           ? JSON.stringify(
               Object.fromEntries(

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -78,6 +78,7 @@ export default {
       showAdvanced: false,
       showParameters: this.flow.parameters?.length > 0,
       parameterDefaults: this.flow.parameters,
+      parameterJsonMode: false,
 
       when: 'now'
     }
@@ -150,7 +151,9 @@ export default {
         if (!obj) return
         Object.keys(obj).forEach(key => {
           try {
-            obj[key] = JSON.parse(obj[key])
+            if (typeof obj[key] == 'string') {
+              obj[key] = JSON.parse(obj[key])
+            }
           } catch {
             //
           }
@@ -169,7 +172,9 @@ export default {
             context: parseObject(this.context),
             id: this.flow.id,
             flowRunName: this.flowRunName,
-            parameters: parseObject(this.parameters),
+            parameters: this.parameterJsonMode
+              ? this.parameters
+              : parseObject(this.parameters),
             scheduledStartTime: this.scheduledStartDateTime,
             runConfig: this.runConfig?.type
               ? { ...this.runConfig, labels: [] }
@@ -190,6 +195,9 @@ export default {
       } finally {
         this.loading = false
       }
+    },
+    handleToggleJsonEditor(val) {
+      this.parameterJsonMode = val
     },
     handleLabelInput(val) {
       this.labels = val
@@ -426,6 +434,7 @@ export default {
               :dict="parameterItems"
               disable-edit
               allow-reset
+              @toggle-json-editor="handleToggleJsonEditor"
             />
           </v-col>
         </v-row>


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes an issue where the editor would incorrectly coerce single-item arrays to scalar values and non-strings to strings in JSON editing mode on the run page.