### PR TITLE
Fix Bash syntax error in start_server.sh

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -2,7 +2,18 @@
 
 # Pipes configured environment variables into the 
 # server settings.json file
-if [[ -z PREFECT_SERVER__APOLLO_URL || -z PREFECT_SERVER__BASE_URL ]]; then echo "missing PREFECT_SERVER__APOLLO_URL or PREFECT_SERVER__BASE_URL" && exit 1
+if [[ -z ${PREFECT_SERVER__APOLLO_URL} ]]
+then
+    echo "Missing the PREFECT_SERVER__APOLLO_URL environment variable."
+    exit 1
+fi
+
+if [[ -z ${PREFECT_SERVER__BASE_URL} ]]
+then
+    echo "Missing the PREFECT_SERVER__BASE_URL environment variable."
+    exit 1
+fi
+
 echo "{\n  \"server_url\": \"$PREFECT_SERVER__APOLLO_URL\",\n  \"base_url\": \"$PREFECT_SERVER__BASE_URL\"\n}" > /var/www/settings.json
 
 echo "👾👾👾 UI running at localhost:8080 👾👾👾"


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR

The Prefect UI Docker entrypoint is currently broken because the `start_server.sh` script has a syntax error. Bash expects a `fi` keyword to close out an `if` statement before the end of the file.

This amends a change introduced in PR #958.

You can verify both the bug and the fix by copy-and-pasting this Bash script into https://www.shellcheck.net/.