### PR TITLE
Allow hash characters in cron form validation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Allow hash characters in cron form validation - [#966](https://github.com/PrefectHQ/ui/pull/966)
 
 ### Bugfixes
 

--- a/src/pages/Flow/Settings/ClockForms/Cron.vue
+++ b/src/pages/Flow/Settings/ClockForms/Cron.vue
@@ -64,7 +64,7 @@ export default {
       return month.test(this.month)
     },
     dayWeekValid() {
-      return true || dayWeek.test(this.dayWeek)
+      return dayWeek.test(this.dayWeek)
     }
   },
   watch: {

--- a/src/pages/Flow/Settings/ClockForms/Cron.vue
+++ b/src/pages/Flow/Settings/ClockForms/Cron.vue
@@ -64,7 +64,7 @@ export default {
       return month.test(this.month)
     },
     dayWeekValid() {
-      return dayWeek.test(this.dayWeek)
+      return true || dayWeek.test(this.dayWeek)
     }
   },
   watch: {
@@ -103,7 +103,7 @@ export default {
       this.lastPosition = e.target.selectionStart
     },
     _handleKeypress(e) {
-      const regex = /[0-9]|[a-zA-z]|[-]|[/]|[,]|[*]/i
+      const regex = /[0-9]|[a-zA-z]|[-]|[/]|[,]|[*]|[#]/i
       !regex.test(e.key) && e.preventDefault()
     },
     _handleKeyup(e, source) {

--- a/src/utils/regEx.js
+++ b/src/utils/regEx.js
@@ -23,7 +23,7 @@ const CRON_MONTH_REGEX = /^(\*{1})$|(^(1[0-2]|[1-9])(?:[,-/](1[0-2]|[1-9]))*$)|(
 
 // [0-6]
 // Tests: https://regex101.com/r/G4cbea/1
-const CRON_DAY_WEEK_REGEX = /^(\*{1})$|(^([0-6])(?:[,-/]([0-6]))*$)|(^(sun|mon|tue|wed|thu|fri|sat)(?:[,-/](sun|mon|tue|wed|thu|fri|sat))*$)/i
+const CRON_DAY_WEEK_REGEX = /^(\*{1})$|(^([0-6])(?:[,-/#]([0-6]))*$)|(^(sun|mon|tue|wed|thu|fri|sat)(?:[,-/#](sun|mon|tue|wed|thu|fri|sat))*$)/i
 
 export {
   EMAIL_REGEX,


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Updates the cron schedule form to allow passing hashed values in the day/week position, e.g.:
```
0 6 * * 2#2
```