### PR TITLE
Fix start server settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ RUN sed -i 's,listen       80;,listen       8080;,' /etc/nginx/conf.d/default.co
 RUN chown -R $UID:0 /var/cache/nginx \
     && chmod -R g+w /var/cache/nginx \
     && chown -R $UID:0 /etc/nginx \
-    && chmod -R g+w /etc/nginx
+    && chmod -R g+w /etc/nginx \
+    && chown -R $UID:0 /var/www \
+    && chmod -R g+w /var/www
 
 USER $UID
 

--- a/public/settings.json
+++ b/public/settings.json
@@ -1,4 +1,4 @@
 {
-    "server_url": "http://localhost:4200/graphql",
-    "base_url": "/"
+    "server_url": "PREFECT_SERVER__APOLLO_URL",
+    "base_url": "PREFECT_SERVER__BASE_URL"
 }

--- a/start_server.sh
+++ b/start_server.sh
@@ -14,8 +14,8 @@ then
     PREFECT_SERVER__BASE_URL="/"
 fi
 
-sed -i /var/www/settings.json "s/PREFECT_SERVER__APOLLO_URL/$PREFECT_SERVER__APOLLO_URL/g"
-sed -i /var/www/settings.json "s/PREFECT_SERVER__BASE_URL/$PREFECT_SERVER__BASE_URL/g"
+sed -i "s,PREFECT_SERVER__APOLLO_URL,$PREFECT_SERVER__APOLLO_URL," /var/www/settings.json 
+sed -i "s,PREFECT_SERVER__BASE_URL,$PREFECT_SERVER__BASE_URL," /var/www/settings.json
 
 echo "👾👾👾 UI running at localhost:8080 👾👾👾"
 

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
 
-# Pipes configured environment variables into the 
-# server settings.json file
+# Set default prefect_ui_settings if
+# env vars not present
 if [[ -z ${PREFECT_SERVER__APOLLO_URL} ]]
 then
-    echo "Missing the PREFECT_SERVER__APOLLO_URL environment variable."
-    exit 1
+    echo "Missing the PREFECT_SERVER__APOLLO_URL environment variable.  Using default"
+    PREFECT_SERVER__APOLLO_URL="http://localhost:4200/graphql"
 fi
 
 if [[ -z ${PREFECT_SERVER__BASE_URL} ]]
 then
-    echo "Missing the PREFECT_SERVER__BASE_URL environment variable."
-    exit 1
+    echo "Missing the PREFECT_SERVER__BASE_URL environment variable.  Using default"
+    PREFECT_SERVER__BASE_URL="/"
 fi
 
-echo "{\n  \"server_url\": \"$PREFECT_SERVER__APOLLO_URL\",\n  \"base_url\": \"$PREFECT_SERVER__BASE_URL\"\n}" > /var/www/settings.json
+sed -i /var/www/settings.json "s/PREFECT_SERVER__APOLLO_URL/$PREFECT_SERVER__APOLLO_URL/g"
+sed -i /var/www/settings.json "s/PREFECT_SERVER__BASE_URL/$PREFECT_SERVER__BASE_URL/g"
 
 echo "👾👾👾 UI running at localhost:8080 👾👾👾"
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
give non-root nginx user privileges over /var/www in Docker image
institute placeholders and use `sed` to replace them at runtime for serving Server settings at /settings.json

fixes a bug introduced when introducing non-root nginx user and removing jq from the image here https://github.com/PrefectHQ/ui/pull/958