### PR TITLE
Fall back to in-memory token exchange if worker exchange fails or takes too long

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix token worker error handling - [#981](https://github.com/PrefectHQ/ui/pull/981)
 
 ## 2021-07-29
 

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -62,16 +62,24 @@ if (TokenWorker?.port) {
         }
         break
       case 'console':
+        // eslint-disable-next-line no-console
+        console.log('TokenWorker console', payload)
+        LogRocket.track('TokenWorker console', payload)
+        break
       case 'error':
-        LogRocket.track('TokenWorker Message', payload)
+        // eslint-disable-next-line no-console
+        console.log('TokenWorker error', payload)
+        LogRocket.captureException(payload)
         break
       default:
+        // eslint-disable-next-line no-console
+        console.log('default', payload)
+        LogRocket.track('TokenWorker Message', payload)
         break
     }
   }
 
-  // TODO: Implement error handling from the token worker
-  TokenWorker.port.onmessageerror = e => {
+  TokenWorker.onerror = e => {
     // eslint-disable-next-line no-console
     console.log('Error message received from Token Worker', e)
     LogRocket.captureException(e)

--- a/src/main.js
+++ b/src/main.js
@@ -70,7 +70,6 @@ export const setStartupTenant = async () => {
 const timeout = async (main, fallback, fallbackargs, time) =>
   Promise.race([main, new Promise((_r, rej) => setTimeout(rej, time))]).catch(
     () => {
-      console.log('promise did not return in time')
       localStorage.setItem('prefect_fallback_auth', Date.now())
       return fallback(...fallbackargs)
     }

--- a/src/main.js
+++ b/src/main.js
@@ -67,6 +67,15 @@ export const setStartupTenant = async () => {
   }
 }
 
+const timeout = async (main, fallback, fallbackargs, time) =>
+  Promise.race([main, new Promise((_r, rej) => setTimeout(rej, time))]).catch(
+    () => {
+      console.log('promise did not return in time')
+      localStorage.setItem('prefect_fallback_auth', Date.now())
+      return fallback(...fallbackargs)
+    }
+  )
+
 let loading = false
 export const start = async () => {
   if (
@@ -84,7 +93,20 @@ export const start = async () => {
     // if the user is requesting a different tenant (indicated by the URL),
     // we swap out these tokens later
     loading = true
-    const tokens = await login()
+
+    let tokens
+
+    // We check local storage for a fallback token and compare it against
+    // the curent timestamp - 1 minute. If it falls outside that window
+    // we attempt the normal flow
+    const fallbackTimestamp = localStorage.getItem('prefect_fallback_auth')
+
+    // We coerce the timestamp because localstorage stores it as a string
+    if (fallbackTimestamp && +fallbackTimestamp > Date.now() - 60000) {
+      tokens = await login(true)
+    } else {
+      tokens = await timeout(login(), login, [true], 10000)
+    }
 
     if (tokens) {
       try {
@@ -94,10 +116,12 @@ export const start = async () => {
           authorizationTokenExpiration:
             tokens.authorizationTokens?.expires_at || 'No authorization token'
         })
-      } catch {
-        // do nothing if this fails
+
+        console.log('TOKEN SOURCE: ', tokens.source)
+      } catch (e) {
+        LogRocket.captureException(e)
       }
-    }
+    } else return
 
     commitTokens(tokens)
 

--- a/src/main.js
+++ b/src/main.js
@@ -116,8 +116,6 @@ export const start = async () => {
           authorizationTokenExpiration:
             tokens.authorizationTokens?.expires_at || 'No authorization token'
         })
-
-        console.log('TOKEN SOURCE: ', tokens.source)
       } catch (e) {
         LogRocket.captureException(e)
       }

--- a/src/plugins/logrocket.js
+++ b/src/plugins/logrocket.js
@@ -59,6 +59,8 @@ const initializeLogrocket = () => {
         }
       }
     })
+
+    LogRocket.identify('Initialized no user')
   }
 }
 

--- a/tests/unit/auth/index.spec.js
+++ b/tests/unit/auth/index.spec.js
@@ -119,7 +119,7 @@ describe('the auth module', () => {
       beforeEach(clearMocks)
 
       it('calls the promiseChannel method when a token worker exists', async () => {
-        await mod.login('foo')
+        await mod.login()
         expect(promiseChannel).toHaveBeenCalledWith(TokenWorker, 'login')
       })
 
@@ -133,7 +133,7 @@ describe('the auth module', () => {
             expiresAt: expiration
           }
           promiseChannel.mockReturnValueOnce(idToken)
-          await mod.login('bar')
+          await mod.login()
 
           expect(expiration).toBeLessThan(Date.now())
           expect(authenticate).toHaveBeenCalledTimes(1)
@@ -146,7 +146,7 @@ describe('the auth module', () => {
         it('calls the authenticate method', async () => {
           const idToken = undefined
           promiseChannel.mockReturnValueOnce(idToken)
-          await mod.login('bar')
+          await mod.login()
           expect(authenticate).toHaveBeenCalledTimes(1)
         })
       })
@@ -156,7 +156,7 @@ describe('the auth module', () => {
         promiseChannel.mockReturnValueOnce(undefined)
         authenticate.mockReturnValueOnce({ idToken: idToken })
 
-        await mod.login('bar')
+        await mod.login()
 
         expect(authenticate).toHaveBeenCalledTimes(1)
         expect(postMessage).toHaveBeenCalledWith({


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
Introduces an arg to the `login` method that immediately falls back to in-memory token exchange instead of using the worker. The startup method now uses a promise race with a 10 second timeout to take advantage of this if the worker throws an error on login or takes too long.

Depends on #980 and #981 