### PR TITLE
Update the data store retrieval patterns to handle more than 1000 flows

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -77,7 +77,7 @@ export default {
       'isCloud'
     ]),
     ...mapGetters('alert', ['getAlert']),
-    ...mapGetters('data', ['projects']),
+    ...mapGetters('data', ['projects', 'flows']),
     ...mapGetters('auth', ['isAuthenticated', 'isAuthorized']),
     ...mapGetters('tenant', [
       'tenant',
@@ -294,7 +294,10 @@ export default {
       pollInterval: 10000,
       update(data) {
         if (!data?.flow || this.isLoadingTenant) return []
-        this.setFlows(data.flow)
+        // Dedupes incoming flows
+        const flows =
+          this.flows?.filter(f => !data.flow.find(_f => _f.id == f.id)) || []
+        this.setFlows([...flows, ...data.flow])
         return data.flow
       }
     })

--- a/src/graphql/Nav/flow.gql
+++ b/src/graphql/Nav/flow.gql
@@ -1,0 +1,11 @@
+query Flows($id: uuid) {
+  flow(
+    where: { _or: [{ id: { _eq: $id } }, { flow_group_id: { _eq: $id } }] }
+  ) {
+    id
+    flow_group_id
+    name
+    project_id
+    is_schedule_active
+  }
+}

--- a/src/graphql/Nav/flow.gql
+++ b/src/graphql/Nav/flow.gql
@@ -1,4 +1,4 @@
-query Flows($id: uuid) {
+query Flow($id: uuid) {
   flow(
     where: { _or: [{ id: { _eq: $id } }, { flow_group_id: { _eq: $id } }] }
   ) {

--- a/src/store/data/index.js
+++ b/src/store/data/index.js
@@ -146,9 +146,17 @@ const actions = {
       id = flow?.id || id
 
       const { data } = await fallbackApolloClient.query({
-        query: require('@/graphql/Nav/flows.gql')
+        query: require('@/graphql/Nav/flow.gql'),
+        variables: {
+          id: id
+        }
       })
-      commit('setFlows', data.flow)
+
+      // Dedupes incoming flows
+      const flows =
+        getters['flows']?.filter(f => !data.flow.find(_f => _f.id == f.id)) ||
+        []
+      commit('setFlows', [...flows, ...data.flow])
 
       flow = getters['flows']?.find(f => f.id == id || f.flow_group_id == id)
     }

--- a/tests/unit/store/data.spec.js
+++ b/tests/unit/store/data.spec.js
@@ -45,6 +45,7 @@ jest.mock('@/vue-apollo', () => {
 })
 
 jest.mock('@/graphql/Nav/flows.gql', () => 'flows query string')
+jest.mock('@/graphql/Nav/flow.gql', () => 'flow query string')
 jest.mock('@/graphql/Nav/projects.gql', () => 'projects query string')
 jest.mock('@/graphql/Nav/task.gql', () => 'tasks query string')
 


### PR DESCRIPTION

PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes an issue where we were unable to fetch flows from the store because of a cap of 1000 items retrieved from the API. This modifies the `activateFlow` method to instead fetch only 1 flow and insert it into the store instead of attempting to retrieve all of them. 