### PR TITLE
Separate primary and secondary Apollo client links

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Separate primary and secondary Apollo client links - [#987](https://github.com/PrefectHQ/ui/pull/987)
 
 ### Bugfixes
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR removes the Batch link from the secondary Apollo client, which is used for non-component-based API requests (like auth, api status, etc). This results in significant improvements in load time (up to 40% faster over the current setup) due to these requests no longer needing to wait for the batch interval to complete. 

I've also increased the batch interval for the primary Apollo client to 2 seconds (up from 1 second) and increased the batch size to 25 (up from 20). Overall this should have very little visible impact on load times but will offset any potential increase in requests from the secondary client. 