### PR TITLE
Auto-populate flow group schedules when editing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Auto-populate schedules form - [#989](https://github.com/PrefectHQ/ui/pull/989)
 
 ### Bugfixes
 

--- a/src/pages/Flow/Settings.vue
+++ b/src/pages/Flow/Settings.vue
@@ -23,7 +23,7 @@ export default {
   },
   data() {
     return {
-      tab: 2
+      tab: 0
     }
   },
   computed: {

--- a/src/pages/Flow/Settings.vue
+++ b/src/pages/Flow/Settings.vue
@@ -23,7 +23,7 @@ export default {
   },
   data() {
     return {
-      tab: 0
+      tab: 2
     }
   },
   computed: {

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -17,6 +17,11 @@ export default {
     SimpleForm
   },
   props: {
+    clock: {
+      type: Object,
+      required: false,
+      default: {}
+    },
     cron: {
       type: String,
       required: false,
@@ -65,7 +70,7 @@ export default {
       advancedTypes: ['cron', 'interval'],
       cronModel: this.cron,
       intervalModel: this.interval,
-      simpleModel: '0 * * * *',
+      simpleModel: this.clock.cron || this.clock.interval || '0 * * * *',
       valid: true
     }
   },

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -20,7 +20,9 @@ export default {
     clock: {
       type: Object,
       required: false,
-      default: {}
+      default: () => {
+        return {}
+      }
     },
     cron: {
       type: String,

--- a/src/pages/Flow/Settings/ClockForms/Simple.vue
+++ b/src/pages/Flow/Settings/ClockForms/Simple.vue
@@ -103,6 +103,18 @@ export default {
       this.$emit('input', val)
     }
   },
+  mounted() {
+    if (!this.value) return
+    console.log(this.value)
+    if (typeof this.value == 'number') {
+      this.interval = 'minute'
+      this.intervalValue = this.value / 60000000
+      return
+    }
+    const [minute, hour, day, month, dayWeek] = this.value.split(' ')
+
+    console.log(minute, hour, day, month, dayWeek)
+  },
   methods: {
     ordinal(val) {
       return ordinal(val)

--- a/src/pages/Flow/Settings/ClockForms/Simple.vue
+++ b/src/pages/Flow/Settings/ClockForms/Simple.vue
@@ -34,7 +34,6 @@ export default {
   computed: {
     clock() {
       let cron = ''
-
       switch (this.interval) {
         case 'minute':
           cron = this.intervalValue * 60000000
@@ -111,7 +110,33 @@ export default {
       this.intervalValue = this.value / 60000000
       return
     }
+
     const [minute, hour, day, month, dayWeek] = this.value.split(' ')
+
+    if (hour.includes('*/')) {
+      this.minuteValue = parseInt(minute)
+      this.interval = 'hour'
+      this.intervalValue = parseInt(hour.split('*/')[1])
+    }
+
+    if (day.includes('*/')) {
+      this.interval = 'day'
+      this.hourValue = parseInt(hour)
+
+      this.intervalValue = parseInt(day.split('*/')[1])
+    }
+
+    if (dayWeek !== '*') {
+      this.interval = 'week'
+      this.dayWeekValue = dayWeek.split(',').map(v => parseInt(v))
+      this.intervalValue = 1
+    }
+
+    if (month.includes('1/')) {
+      this.interval = 'month'
+      this.dayMonthValue = day.split(',').map(v => parseInt(v))
+      this.intervalValue = parseInt(month.split('1/')[1])
+    }
 
     console.log(minute, hour, day, month, dayWeek)
   },
@@ -151,9 +176,10 @@ export default {
       <div>Run every</div>
 
       <v-text-field
+        v-if="interval !== 'week'"
         v-model.number="intervalValue"
         type="number"
-        class="text-h5 mx-2"
+        class="text-h5 ml-2"
         outlined
         dense
         hide-details
@@ -165,7 +191,7 @@ export default {
       <v-select
         v-model="interval"
         :items="intervalOptions"
-        class="text-h5"
+        class="text-h5 ml-2"
         outlined
         dense
         hide-details

--- a/src/pages/Flow/Settings/ClockForms/Simple.vue
+++ b/src/pages/Flow/Settings/ClockForms/Simple.vue
@@ -104,7 +104,6 @@ export default {
   },
   mounted() {
     if (!this.value) return
-    console.log(this.value)
     if (typeof this.value == 'number') {
       this.interval = 'minute'
       this.intervalValue = this.value / 60000000
@@ -137,8 +136,6 @@ export default {
       this.dayMonthValue = day.split(',').map(v => parseInt(v))
       this.intervalValue = parseInt(month.split('1/')[1])
     }
-
-    console.log(minute, hour, day, month, dayWeek)
   },
   methods: {
     ordinal(val) {

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -435,6 +435,7 @@ export default {
               <div v-show="selectedTab === 0">
                 <ClockForm
                   :flow-group-clocks="flowGroupClocks"
+                  :clock="clock"
                   :cron="clock.cron"
                   :param="parameter"
                   :interval="clock.interval"

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -565,9 +565,10 @@ export default {
                 </v-col>
                 <v-col
                   cols="2"
-                  class="d-flex align-center flex-column justify-end pa-1 my-auto"
-                  style="border-left: 1px solid utilGrayLight;
-          height: 90%;"
+                  class="d-flex align-center flex-column justify-end pa-1"
+                  style="
+                    border-left: 1px solid var(--v-utilGrayLight-base);
+                    height: 100%;"
                 >
                   <v-menu
                     v-model="clock.contextMenu"


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Auto-populates schedules when modifying previously created ones. Also retunes the weekly interval schedule to make more sense and fixes a bug where it wasn't creating a schedule with the correct interval.

Resolves #838