### PR TITLE
Expose retry for archived runs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@
 - Add new login logic to browser visibility handler - [#986](https://github.com/PrefectHQ/ui/pull/986)
 
 ### Bugfixes
+
+- Expose restart from failed button for archived flows - [#1002](https://github.com/PrefectHQ/ui/pull/1002)
+- Only display Core Version for Server deploys - [#1002](https://github.com/PrefectHQ/ui/pull/1002)
 - Don't show user and read only for accounts without RBAC -[#1001](https://github.com/PrefectHQ/ui/pull/1001)
 - Add host config to the docker run config - [#988](https://github.com/PrefectHQ/ui/pull/988)
 - Add secret name and value routes to limit and offset exceptions - [#955](https://github.com/PrefectHQ/ui/pull/955)

--- a/src/components/Nav/TeamSideNav.vue
+++ b/src/components/Nav/TeamSideNav.vue
@@ -330,7 +330,7 @@ export default {
               <div>{{ lastDeployment_UI }}</div>
             </div>
             <div class="flex-grow-1">
-              <div v-show="coreVersion" class="text-center mb-2">
+              <div v-show="coreVersion && isServer" class="text-center mb-2">
                 <div class="utilGrayMid--text font-weight-light">
                   Core Version
                 </div>

--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -47,9 +47,8 @@ export default {
     },
     canRestart() {
       return (
-        !this.flowRun.flow.archived &&
-        (this.failedTaskRuns?.length > 0 ||
-          this.eligibleStates.includes(this.flowRun.state))
+        this.failedTaskRuns?.length > 0 ||
+        this.eligibleStates.includes(this.flowRun.state)
       )
     }
   },
@@ -190,8 +189,7 @@ export default {
         You don't have permission to restart flow runs
       </span>
       <span v-else-if="!canRestart"
-        >You can only restart non-archived flow runs from a failed or cancelled
-        state.
+        >You can only restart flow runs from a failed or cancelled state.
         <span v-if="isFinished"
           >If you wish to run this flow run again, you can set it (and its task
           runs) into a scheduled state.</span


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This PR makes two minor adjustments:

- new runs cannot be created for archived flows; _however_, runs that already exist for archived flows can still be resubmitted / interacted with.  We found some users who used this functionality by restarting flow runs corresponding to archived flows via the UI -- the "restart" button was being exposed on individual task run pages but not on the main flow run page.  This PR now exposes that button for user convenience (**cc:** @dylanbhughes )
- the Core Version deployed with the backend is only relevant information for Prefect Server deploys (as it essentially proxies the version of Server) but is not relevant for Prefect Cloud's UI; this PR hides this info for Cloud only