### PR TITLE
Check authorization token expiration on initial login flow

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix an issue where the authorization token expiration wasn't being converted properly on initial check - [#1006](https://github.com/PrefectHQ/ui/pull/1006)
 
 ## 2021-08-17
 

--- a/src/main.js
+++ b/src/main.js
@@ -111,7 +111,8 @@ export const start = async () => {
       try {
         LogRocket.track('Tokens', {
           source: tokens.source || 'No source',
-          idTokenExpiration: tokens.idToken?.expiresAt * 1000 || 'No id token',
+          idTokenExpiration:
+            new Date(tokens.idToken?.expiresAt)?.toString() || 'No id token',
           authorizationTokenExpiration:
             tokens.authorizationTokens?.expires_at || 'No authorization token'
         })

--- a/src/workers/auth.worker.js
+++ b/src/workers/auth.worker.js
@@ -154,7 +154,7 @@ const handleAuthorize = async idToken => {
   authorizing = true
   if (
     !state.authorizationToken ||
-    state.authorizationToken.expires_at <= Date.now()
+    new Date(state.authorizationToken.expires_at) <= Date.now()
   ) {
     const authorizationResponse = await authorize(idToken)
 


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
This fixes an issue where the authorization token expiration wasn't being converted properly in the initial expiration check on login, which was leading to infinite loading screens for some users. 