### PR TITLE
Cut changelog ahead of 2021-08-18 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,12 @@
 
 ### Bugfixes
 
+- None
+
+## 2021-08-18
+
+### Bugfixes
+
 - Fix an issue where the authorization token expiration wasn't being converted properly on initial check - [#1006](https://github.com/PrefectHQ/ui/pull/1006)
 
 ## 2021-08-17


### PR DESCRIPTION
## 2021-08-18

### Bugfixes

- Fix an issue where the authorization token expiration wasn't being converted properly on initial check - [#1006](https://github.com/PrefectHQ/ui/pull/1006)