### PR TITLE
Skipped state duration and end time fix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 ### Bugfixes
 
+- Fix issue where Skipped flow runs incorrectly displayed end_time and duration data - [#1030](https://github.com/PrefectHQ/ui/pull/1030)
 - Stop role reset in the team member invite dialog - [#1019](https://github.com/PrefectHQ/ui/pull/1019)
 
 ## 2021-08-18

--- a/src/components/TimelineTooltip.vue
+++ b/src/components/TimelineTooltip.vue
@@ -60,7 +60,13 @@ export default {
         </span>
       </div>
 
-      <div v-if="props.tooltip.data.start_time" class="text-subtitle-1">
+      <div
+        v-if="
+          props.tooltip.data.start_time &&
+            (props.tooltip.data.end_time || !props.tooltip.data.finished)
+        "
+        class="text-subtitle-1"
+      >
         Duration:
         <component
           :is="$options.components.DurationSpan"

--- a/src/mixins/flowRunHistoryMixin.js
+++ b/src/mixins/flowRunHistoryMixin.js
@@ -101,7 +101,7 @@ export const flowRunHistoryMixin = {
           let end = new Date(d.end_time),
             start = new Date(d.start_time)
           d.duration = end - start
-        } else if (d.start_time) {
+        } else if (d.start_time && notPastRunStates.includes(d.state)) {
           let now = new Date(),
             start = new Date(d.start_time)
           d.duration = now - start
@@ -113,10 +113,13 @@ export const flowRunHistoryMixin = {
         if (
           !d.end_time &&
           d.start_time &&
-          !notPastRunStates.includes(d.state)
+          !notPastRunStates.includes(d.state) &&
+          d.state !== 'Skipped'
         ) {
           d.end_time = new Date()
         }
+
+        d.finished = !notPastRunStates.includes(d.state)
 
         // We do the same for running flows without start_time
         if (!d.start_time && d.state == 'Running') {


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR
Fixes a bug where flow runs in a `Skipped` incorrectly populated the end_time field and never capped durations.

Resolves: #1000 
Resolves: https://github.com/PrefectHQ/prefect/issues/4864