### PR TITLE
member invitation bug - invite a user on the free tier the first time the modal appears

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 
 ### Bugfixes
 
-- None
+- Fix member invitation bug - [#1062](https://github.com/PrefectHQ/ui/pull/1062)
 
 ## 2021-09-20
 

--- a/src/pages/TeamSettings/Members.vue
+++ b/src/pages/TeamSettings/Members.vue
@@ -143,6 +143,10 @@ export default {
   },
   methods: {
     ...mapActions('alert', ['setAlert']),
+    handleInviteDialog() {
+      this.roleInput = this.roles?.find(r => r.name == 'TENANT_ADMIN').id
+      this.dialogInviteUser = true
+    },
     handleAlert(type, message) {
       this.setAlert({
         alertShow: true,
@@ -222,9 +226,6 @@ export default {
       })
     }
   },
-  created() {
-    this.roleInput = this.roles?.find(r => r.name == 'TENANT_ADMIN').id
-  },
   apollo: {
     roles: {
       query: require('@/graphql/TeamSettings/roles.gql'),
@@ -262,7 +263,7 @@ export default {
         class="white--text"
         large
         data-cy="invite-member"
-        @click="dialogInviteUser = true"
+        @click="handleInviteDialog"
       >
         <v-icon left>
           person_add


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Should resolve #1059 