### PR TITLE
when creating/editing schedule, make action button available across tabs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Features and Improvements
 
+- When creating/editing schedule, make action button available across tabs - [#1096](https://github.com/PrefectHQ/ui/pull/1096)
 - Add warning that users will be locked out if not part of a team - [#1078](https://github.com/PrefectHQ/ui/pull/1078)
 - Update the PagerDuty logo to match new branding - [#1073](https://github.com/PrefectHQ/ui/pull/1073)
 

--- a/src/components/PrefectSchedule.vue
+++ b/src/components/PrefectSchedule.vue
@@ -9,7 +9,7 @@ export default {
     schedule: {
       required: true,
       type: Object,
-      validator: schedule => schedule.type
+      validator: schedule => schedule?.type || typeof schedule
     }
   },
   computed: {

--- a/src/components/PrefectSchedule.vue
+++ b/src/components/PrefectSchedule.vue
@@ -9,7 +9,7 @@ export default {
     schedule: {
       required: true,
       type: Object,
-      validator: schedule => schedule?.type || typeof schedule
+      validator: schedule => schedule.type
     }
   },
   computed: {

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -121,7 +121,7 @@ export default {
       }
       return parameters
     },
-    checkDefualtParameters(parameterObj) {
+    checkDefaultParameters(parameterObj) {
       return Object.values(parameterObj).length > 0
     },
     removeDoubleParam(clock) {
@@ -279,7 +279,7 @@ export default {
 
     <div v-show="selectedTab === 1">
       <div
-        v-if="!checkDefualtParameters(allDefaultParameters)"
+        v-if="!checkDefaultParameters(allDefaultParameters)"
         class="mt-8 text-body-1"
       >
         This flow has no default parameters.

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -164,8 +164,7 @@ export default {
           ? this.selectedTimezone
           : this.simpleSelectedTimezone
       }
-      console.log('CLOCK', clock)
-      //this.$emit('confirm', clock)
+      this.$emit('confirm', clock)
     }
   }
 }

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -4,6 +4,8 @@
 import CronForm from '@/pages/Flow/Settings/ClockForms/Cron'
 import IntervalForm from '@/pages/Flow/Settings/ClockForms/Interval'
 import SimpleForm from '@/pages/Flow/Settings/ClockForms/Simple'
+import DictInput from '@/components/CustomInputs/DictInput'
+
 import moment from 'moment-timezone'
 
 const timezones = [...moment.tz.names()].map(tz => {
@@ -14,9 +16,15 @@ export default {
   components: {
     CronForm,
     IntervalForm,
-    SimpleForm
+    SimpleForm,
+    DictInput
   },
   props: {
+    selectedTab: {
+      type: [Number, String],
+      required: false,
+      default: () => 0
+    },
     clock: {
       type: Object,
       required: false,
@@ -45,7 +53,7 @@ export default {
       default: () => null
     },
     param: {
-      type: Object,
+      type: [Object, Array],
       required: false,
       default: () => null
     },
@@ -73,7 +81,8 @@ export default {
       cronModel: this.cron,
       intervalModel: this.interval,
       simpleModel: this.clock.cron || this.clock.interval || '0 * * * *',
-      valid: true
+      valid: true,
+      parameter: {}
     }
   },
   computed: {
@@ -109,11 +118,12 @@ export default {
         [clockType == 'IntervalClock' ? 'interval' : 'cron']: this[
           this.clockToAdd
         ],
-        parameter_defaults: this.param ? parseObject(this.param) : {},
+        parameter_defaults: this.parameter ? parseObject(this.parameter) : {},
         timezone: this.advanced
           ? this.selectedTimezone
           : this.simpleSelectedTimezone
       }
+
       this.$emit('confirm', clock)
     }
   }
@@ -121,107 +131,122 @@ export default {
 </script>
 
 <template>
-  <v-container
-    class="d-flex flex-column align-start justify-start"
-    style="height: 100%;
-    width: 100%;"
-  >
-    <div class="d-flex justify-end mb-1" style="width: 100%;">
-      <v-switch
-        v-model="advanced"
-        inset
-        label="Advanced"
-        class="mt-0"
-        hide-details
-      ></v-switch>
-    </div>
-    <v-card-text
-      style="max-height: fill;
-      overflow: auto;"
+  <div>
+    <div
+      class="d-flex flex-column align-start justify-start"
+      style="height: 100%;width: 100%;"
     >
-      <v-fade-transition mode="out-in">
-        <div
-          v-if="advanced"
-          key="1"
-          class="mt-4 d-block"
-          style="max-width: 100%;"
-        >
-          <v-chip-group v-model="advancedType" column mandatory>
-            <v-chip
-              v-for="type in advancedTypes"
-              :key="type"
-              active-class="primary"
-              class="px-6 text-capitalize"
-              label
-              :value="type"
-            >
-              {{ type }}
-            </v-chip>
-          </v-chip-group>
+      <div class="d-flex justify-end mb-1" style="width: 100%;">
+        <v-switch
+          v-show="selectedTab === 0"
+          v-model="advanced"
+          inset
+          label="Advanced"
+          class="mt-0"
+          hide-details
+        ></v-switch>
+      </div>
 
-          <v-fade-transition mode="out-in">
-            <div v-if="advancedType == 'cron'" key="Cron">
-              <CronForm v-model="cronModel" :valid.sync="valid" class="mt-2" />
-              <v-autocomplete
-                v-model="selectedTimezone"
-                :items="tzs"
-                outlined
-                label="Time Zone"
-                style="margin-top: 110px;"
-                prepend-inner-icon="access_time"
-                :menu-props="{ contentClass: 'tz' }"
-              />
-
-              <v-alert
-                v-if="flowGroupClocks.length > 0"
-                border="left"
-                colored-border
-                elevation="0"
-                type="warning"
-                dense
-                icon="warning"
-              >
-                <span class="text-body-2 ma-0">
-                  Setting the timezone here will take precedence over existing
-                  flow group schedule timezones
-                </span>
-              </v-alert>
-            </div>
-            <div v-else-if="advancedType == 'interval'" key="Interval">
-              <IntervalForm v-model="intervalModel" class="mt-4" />
-            </div>
-          </v-fade-transition>
-        </div>
-        <div v-else key="2" class="mt-4 d-block" style="max-width: 100%;">
-          <SimpleForm v-model="simpleModel" />
-
-          <v-autocomplete
-            v-if="typeof simpleModel !== 'number'"
-            v-model="simpleSelectedTimezone"
-            :items="tzs"
-            outlined
-            label="Time Zone"
-            prepend-inner-icon="access_time"
-            :menu-props="{ contentClass: 'tz' }"
-          />
-
-          <v-alert
-            v-if="flowGroupClocks.length > 0"
-            border="left"
-            colored-border
-            elevation="0"
-            type="warning"
-            dense
-            icon="warning"
+      <v-card-text
+        v-show="selectedTab === 0"
+        style="max-height: fill;
+      overflow: auto;"
+      >
+        <v-fade-transition mode="out-in">
+          <div
+            v-if="advanced"
+            key="1"
+            class="mt-4 d-block"
+            style="max-width: 100%;"
           >
-            <span class="text-body-2 ma-0">
-              Setting the timezone here will take precedence over existing flow
-              group schedule timezones
-            </span>
-          </v-alert>
-        </div>
-      </v-fade-transition>
-    </v-card-text>
+            <v-chip-group v-model="advancedType" column mandatory>
+              <v-chip
+                v-for="type in advancedTypes"
+                :key="type"
+                active-class="primary"
+                class="px-6 text-capitalize"
+                label
+                :value="type"
+              >
+                {{ type }}
+              </v-chip>
+            </v-chip-group>
+            <v-fade-transition mode="out-in">
+              <div v-if="advancedType == 'cron'" key="Cron">
+                <CronForm
+                  v-model="cronModel"
+                  :valid.sync="valid"
+                  class="mt-2"
+                />
+                <v-autocomplete
+                  v-model="selectedTimezone"
+                  :items="tzs"
+                  outlined
+                  label="Time Zone"
+                  style="margin-top: 110px;"
+                  prepend-inner-icon="access_time"
+                  :menu-props="{ contentClass: 'tz' }"
+                />
+                <v-alert
+                  v-if="flowGroupClocks.length > 0"
+                  border="left"
+                  colored-border
+                  elevation="0"
+                  type="warning"
+                  dense
+                  icon="warning"
+                >
+                  <span class="text-body-2 ma-0">
+                    Setting the timezone here will take precedence over existing
+                    flow group schedule timezones
+                  </span>
+                </v-alert>
+              </div>
+              <div v-else-if="advancedType == 'interval'" key="Interval">
+                <IntervalForm v-model="intervalModel" class="mt-4" />
+              </div>
+            </v-fade-transition>
+          </div>
+          <div v-else key="2" class="mt-4 d-block" style="max-width: 100%;">
+            <SimpleForm v-model="simpleModel" />
+            <v-autocomplete
+              v-if="typeof simpleModel !== 'number'"
+              v-model="simpleSelectedTimezone"
+              :items="tzs"
+              outlined
+              label="Time Zone"
+              prepend-inner-icon="access_time"
+              :menu-props="{ contentClass: 'tz' }"
+            />
+            <v-alert
+              v-if="flowGroupClocks.length > 0"
+              border="left"
+              colored-border
+              elevation="0"
+              type="warning"
+              dense
+              icon="warning"
+            >
+              <span class="text-body-2 ma-0">
+                Setting the timezone here will take precedence over existing
+                flow group schedule timezones
+              </span>
+            </v-alert>
+          </div>
+        </v-fade-transition>
+      </v-card-text>
+    </div>
+
+    <div v-show="selectedTab === 1">
+      <DictInput
+        v-model="parameter"
+        style="padding: 20px;"
+        include-checkbox
+        :dict="param"
+        disable-edit
+        allow-reset
+      />
+    </div>
 
     <div
       style="
@@ -234,7 +259,6 @@ export default {
       <v-btn depressed class="mx-1" @click.stop="cancel">
         Cancel
       </v-btn>
-
       <v-btn
         depressed
         class="mx-1"
@@ -245,7 +269,7 @@ export default {
         {{ createOrSave }}
       </v-btn>
     </div>
-  </v-container>
+  </div>
 </template>
 
 <style>

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -176,7 +176,7 @@ export default {
       class="d-flex flex-column align-start justify-start"
       style="height: 100%;width: 100%;"
     >
-      <div class="d-flex justify-end mt-4" style="width: 100%;">
+      <div class="d-flex justify-end mt-2" style="width: 100%;">
         <v-switch
           v-show="selectedTab === 0"
           v-model="advanced"
@@ -259,9 +259,7 @@ export default {
               :menu-props="{ contentClass: 'tz' }"
             />
             <v-alert
-              v-if="
-                flowGroupClocks.length > 0 && typeof simpleModel !== 'number'
-              "
+              v-if="flowGroupClocks.length > 0"
               border="left"
               colored-border
               elevation="0"
@@ -310,7 +308,7 @@ export default {
     <div
       style="
       bottom: 0;
-      padding: 20px;
+      padding: 15px;
       position: absolute;
       right: 0;
       "

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -124,8 +124,16 @@ export default {
           : this.simpleSelectedTimezone
       }
 
+      //console.log('updating clock', clock)
       this.$emit('confirm', clock)
     }
+  },
+  mounted() {
+    console.log('flow group clocks', this.flowGroupClocks)
+    console.log('clock', this.clock)
+    console.log('parameter', this.param)
+    console.log('interval', this.interval)
+    console.log('timezone', this.timezone)
   }
 }
 </script>
@@ -238,14 +246,24 @@ export default {
     </div>
 
     <div v-show="selectedTab === 1">
-      <DictInput
-        v-model="parameter"
-        style="padding: 20px;"
-        include-checkbox
-        :dict="param"
-        disable-edit
-        allow-reset
-      />
+      <div v-if="param.length > 0">
+        <p class="mt-8 text-body-1">
+          Checked parameters will override their corresponding defaults for runs
+          generated from this schedule.
+        </p>
+        <DictInput
+          v-model="parameter"
+          style="padding: 20px;"
+          include-checkbox
+          :dict="param"
+          disable-edit
+          allow-reset
+        />
+      </div>
+
+      <div v-else class="mt-8 text-body-1">
+        This flow has no default parameters.
+      </div>
     </div>
 
     <div

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -27,7 +27,7 @@ export default {
     },
     selectedTab: {
       type: [Number, String],
-      required: false,
+      required: true,
       default: () => 0
     },
     clock: {
@@ -176,7 +176,7 @@ export default {
       class="d-flex flex-column align-start justify-start"
       style="height: 100%;width: 100%;"
     >
-      <div class="d-flex justify-end mb-1" style="width: 100%;">
+      <div class="d-flex justify-end mt-4" style="width: 100%;">
         <v-switch
           v-show="selectedTab === 0"
           v-model="advanced"
@@ -259,7 +259,9 @@ export default {
               :menu-props="{ contentClass: 'tz' }"
             />
             <v-alert
-              v-if="flowGroupClocks.length > 0"
+              v-if="
+                flowGroupClocks.length > 0 && typeof simpleModel !== 'number'
+              "
               border="left"
               colored-border
               elevation="0"
@@ -284,18 +286,25 @@ export default {
       >
         This flow has no default parameters.
       </div>
-      <DictInput
-        v-else
-        v-model="parameter"
-        style="padding: 20px;"
-        :dict="removeDoubleParam(param)"
-        :default-checked-keys="
-          Object.keys(param ? param : allDefaultParameters)
-        "
-        include-checkbox
-        disable-edit
-        allow-reset
-      />
+
+      <div v-else>
+        <p class="mt-8 text-body-1">
+          Checked parameters will override their corresponding defaults for runs
+          generated from this schedule.
+        </p>
+
+        <DictInput
+          v-model="parameter"
+          style="padding: 20px;"
+          :dict="removeDoubleParam(param)"
+          :default-checked-keys="
+            Object.keys(param ? param : allDefaultParameters)
+          "
+          include-checkbox
+          disable-edit
+          allow-reset
+        />
+      </div>
     </div>
 
     <div

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -61,16 +61,6 @@ export default {
         return c
       })
     },
-    allDefaultParameters() {
-      if (!this.defaultParameters) {
-        return {}
-      }
-      const paramObj = this.defaultParameters.reduce(
-        (obj, item) => ((obj[item.name] = item.default), obj),
-        {}
-      )
-      return this.paramVal(paramObj)
-    },
     hasFlowGroupSchedule() {
       return this.flowGroupClocks && this.flowGroupClocks.length > 0
     }
@@ -253,33 +243,6 @@ export default {
       }
 
       return this.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
-    },
-    paramVal(clock) {
-      if (!clock) {
-        return
-      }
-      let parameters = []
-
-      for (const [key, value] of Object.entries(clock)) {
-        parameters.push({ key: key, value: value, disabled: true })
-      }
-      return parameters
-    },
-    checkDefualtParameters(parameterObj) {
-      return Object.values(parameterObj).length > 0
-    },
-    removeDoubleParam(clock) {
-      if (clock && this.allDefaultParameters.length !== 0) {
-        return Object.values(
-          [...this.allDefaultParameters, ...this.paramVal(clock)]
-            .reverse()
-            .reduce((r, c) => ((r[c.key] = r[c.key] || c), r), {})
-        )
-      }
-
-      if (this.allDefaultParameters.length !== 0) {
-        return this.allDefaultParameters
-      }
     }
   }
 }
@@ -345,11 +308,7 @@ export default {
                       Intl.DateTimeFormat().resolvedOptions().timeZone
                   "
                   :selected-tab="selectedTab"
-                  :param="
-                    checkDefualtParameters(allDefaultParameters)
-                      ? allDefaultParameters
-                      : []
-                  "
+                  :default-parameters="defaultParameters"
                   @cancel="selectedClock = null"
                   @confirm="createClock"
                 />
@@ -410,64 +369,19 @@ export default {
               </v-tabs>
 
               <!-- EDITABLE CLOCKFORM -->
-              {{
-                checkDefualtParameters(allDefaultParameters)
-                  ? allDefaultParameters
-                  : []
-              }}
-              <!-- <ClockForm
+
+              <ClockForm
                 :flow-group-clocks="flowGroupClocks"
                 :clock="clock"
                 :cron="clock.cron"
-                :param="
-                  checkDefualtParameters(allDefaultParameters)
-                    ? allDefaultParameters
-                    : []
-                "
+                :param="clock.parameter_defaults"
                 :interval="clock.interval"
                 :timezone="timezoneVal(clock)"
                 :selected-tab="selectedTab"
+                :default-parameters="defaultParameters"
                 @cancel="selectedClock = null"
                 @confirm="createClock"
-              /> -->
-
-              <!-- <div v-show="selectedTab === 0">
-                <ClockForm
-                  :flow-group-clocks="flowGroupClocks"
-                  :clock="clock"
-                  :cron="clock.cron"
-                  :param="parameter"
-                  :interval="clock.interval"
-                  :timezone="timezoneVal(clock)"
-                  @cancel="selectedClock = null"
-                  @confirm="createClock"
-                />
-              </div>
-              <div v-show="selectedTab === 1">
-                <div
-                  v-if="!checkDefualtParameters(allDefaultParameters)"
-                  class="mt-8 text-body-1"
-                >
-                  <span class="font-weight-bold">{{ flow.name }}</span>
-                  has no default parameters.
-                </div>
-                <DictInput
-                  v-else
-                  v-model="parameter"
-                  style="padding: 20px;"
-                  :dict="removeDoubleParam(clock.parameter_defaults)"
-                  :default-checked-keys="
-                    Object.keys(
-                      clock.parameter_defaults
-                        ? clock.parameter_defaults
-                        : allDefaultParameters
-                    )
-                  "
-                  include-checkbox
-                  disable-edit
-                  allow-reset
-                />
-              </div> -->
+              />
             </div>
 
             <div v-else key="2" style="height: 100%;">

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -7,7 +7,6 @@ import ExternalLink from '@/components/ExternalLink'
 import IntervalClock from '@/components/Functional/IntervalClock'
 import LogRocket from 'logrocket'
 import ClockForm from '@/pages/Flow/Settings/ClockForm'
-import DictInput from '@/components/CustomInputs/DictInput'
 import { parametersMixin } from '@/mixins/parametersMixin.js'
 export default {
   components: {
@@ -15,8 +14,7 @@ export default {
     CronClock,
     ExternalLink,
     IntervalClock,
-    ClockForm,
-    DictInput
+    ClockForm
   },
   mixins: [parametersMixin],
   props: {

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -1,6 +1,4 @@
 <script>
-/* eslint-disable */
-
 import { mapGetters, mapActions } from 'vuex'
 
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -300,7 +298,6 @@ export default {
                   <v-tab>Parameters</v-tab>
                 </v-tabs>
 
-                <!-- CREATION CLOCKFORM -->
                 <ClockForm
                   :flow-group-clocks="flowGroupClocks"
                   :timezone="
@@ -367,8 +364,6 @@ export default {
                 <v-tab>Schedule</v-tab>
                 <v-tab>Parameters</v-tab>
               </v-tabs>
-
-              <!-- EDITABLE CLOCKFORM -->
 
               <ClockForm
                 :flow-group-clocks="flowGroupClocks"

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -61,6 +61,7 @@ export default {
     },
     allDefaultParameters() {
       if (!this.defaultParameters) {
+        console.log(true)
         return {}
       }
       const paramObj = this.defaultParameters.reduce(
@@ -91,27 +92,28 @@ export default {
   methods: {
     ...mapActions('alert', ['setAlert']),
     async createClock(val) {
-      let isNew = false
-      this.loading = true
-      if (this.selectedClock > -1) {
-        this.clocks[this.selectedClock] = {
-          ...this.clocks[this.selectedClock],
-          ...val
-        }
+      console.log('SHCEDULE VAL: ', val)
+      // let isNew = false
+      // this.loading = true
+      // if (this.selectedClock > -1) {
+      //   this.clocks[this.selectedClock] = {
+      //     ...this.clocks[this.selectedClock],
+      //     ...val
+      //   }
 
-        let shifted = [...this.clocks]
-        shifted.unshift(shifted.splice(this.selectedClock, 1)[0])
+      //   let shifted = [...this.clocks]
+      //   shifted.unshift(shifted.splice(this.selectedClock, 1)[0])
 
-        this.clocks = shifted
-      } else {
-        isNew = true
-        this.clocks.push({ ...val, scheduleType: 'flow-group' })
-        this.clocks = this.clocks.reverse()
-      }
+      //   this.clocks = shifted
+      // } else {
+      //   isNew = true
+      //   this.clocks.push({ ...val, scheduleType: 'flow-group' })
+      //   this.clocks = this.clocks.reverse()
+      // }
 
-      await this.modifySchedules({ new: isNew })
-      this.selectedClock = null
-      this.loading = false
+      // await this.modifySchedules({ new: isNew })
+      // this.selectedClock = null
+      // this.loading = false
     },
     async deleteClock() {
       this.loading = true
@@ -338,7 +340,23 @@ export default {
                   <v-tab>Parameters</v-tab>
                 </v-tabs>
 
-                <div v-show="selectedTab === 0">
+                <ClockForm
+                  :flow-group-clocks="flowGroupClocks"
+                  :timezone="
+                    this.timezone ||
+                      Intl.DateTimeFormat().resolvedOptions().timeZone
+                  "
+                  :selected-tab="selectedTab"
+                  :param="
+                    checkDefualtParameters(allDefaultParameters)
+                      ? allDefaultParameters
+                      : []
+                  "
+                  @cancel="selectedClock = null"
+                  @confirm="createClock"
+                />
+
+                <!-- <div v-show="selectedTab === 0">
                   <ClockForm
                     :flow-group-clocks="flowGroupClocks"
                     :param="parameter"
@@ -375,7 +393,7 @@ export default {
                     <span class="font-weight-bold">{{ flow.name }}</span>
                     has no default parameters.
                   </div>
-                </div>
+                </div> -->
               </div>
               <div
                 v-else

--- a/src/pages/Flow/Settings/Schedules.vue
+++ b/src/pages/Flow/Settings/Schedules.vue
@@ -1,4 +1,6 @@
 <script>
+/* eslint-disable */
+
 import { mapGetters, mapActions } from 'vuex'
 
 import ConfirmDialog from '@/components/ConfirmDialog'
@@ -61,7 +63,6 @@ export default {
     },
     allDefaultParameters() {
       if (!this.defaultParameters) {
-        console.log(true)
         return {}
       }
       const paramObj = this.defaultParameters.reduce(
@@ -92,28 +93,24 @@ export default {
   methods: {
     ...mapActions('alert', ['setAlert']),
     async createClock(val) {
-      console.log('SHCEDULE VAL: ', val)
-      // let isNew = false
-      // this.loading = true
-      // if (this.selectedClock > -1) {
-      //   this.clocks[this.selectedClock] = {
-      //     ...this.clocks[this.selectedClock],
-      //     ...val
-      //   }
-
-      //   let shifted = [...this.clocks]
-      //   shifted.unshift(shifted.splice(this.selectedClock, 1)[0])
-
-      //   this.clocks = shifted
-      // } else {
-      //   isNew = true
-      //   this.clocks.push({ ...val, scheduleType: 'flow-group' })
-      //   this.clocks = this.clocks.reverse()
-      // }
-
-      // await this.modifySchedules({ new: isNew })
-      // this.selectedClock = null
-      // this.loading = false
+      let isNew = false
+      this.loading = true
+      if (this.selectedClock > -1) {
+        this.clocks[this.selectedClock] = {
+          ...this.clocks[this.selectedClock],
+          ...val
+        }
+        let shifted = [...this.clocks]
+        shifted.unshift(shifted.splice(this.selectedClock, 1)[0])
+        this.clocks = shifted
+      } else {
+        isNew = true
+        this.clocks.push({ ...val, scheduleType: 'flow-group' })
+        this.clocks = this.clocks.reverse()
+      }
+      await this.modifySchedules({ new: isNew })
+      this.selectedClock = null
+      this.loading = false
     },
     async deleteClock() {
       this.loading = true
@@ -340,6 +337,7 @@ export default {
                   <v-tab>Parameters</v-tab>
                 </v-tabs>
 
+                <!-- CREATION CLOCKFORM -->
                 <ClockForm
                   :flow-group-clocks="flowGroupClocks"
                   :timezone="
@@ -355,45 +353,6 @@ export default {
                   @cancel="selectedClock = null"
                   @confirm="createClock"
                 />
-
-                <!-- <div v-show="selectedTab === 0">
-                  <ClockForm
-                    :flow-group-clocks="flowGroupClocks"
-                    :param="parameter"
-                    :timezone="
-                      this.timezone ||
-                        Intl.DateTimeFormat().resolvedOptions().timeZone
-                    "
-                    @cancel="selectedClock = null"
-                    @confirm="createClock"
-                  />
-                </div>
-                <div v-show="selectedTab === 1">
-                  <p
-                    v-if="checkDefualtParameters(allDefaultParameters)"
-                    class="mt-8 text-body-1"
-                  >
-                    Checked parameters will override their corresponding
-                    defaults for runs generated from this schedule.
-                  </p>
-
-                  <DictInput
-                    v-if="checkDefualtParameters(allDefaultParameters)"
-                    v-model="parameter"
-                    style="padding: 20px;"
-                    include-checkbox
-                    :dict="allDefaultParameters"
-                    disable-edit
-                    allow-reset
-                  />
-                  <div
-                    v-else-if="!checkDefualtParameters(allDefaultParameters)"
-                    class="mt-8 text-body-1"
-                  >
-                    <span class="font-weight-bold">{{ flow.name }}</span>
-                    has no default parameters.
-                  </div>
-                </div> -->
               </div>
               <div
                 v-else
@@ -450,7 +409,29 @@ export default {
                 <v-tab>Parameters</v-tab>
               </v-tabs>
 
-              <div v-show="selectedTab === 0">
+              <!-- EDITABLE CLOCKFORM -->
+              {{
+                checkDefualtParameters(allDefaultParameters)
+                  ? allDefaultParameters
+                  : []
+              }}
+              <!-- <ClockForm
+                :flow-group-clocks="flowGroupClocks"
+                :clock="clock"
+                :cron="clock.cron"
+                :param="
+                  checkDefualtParameters(allDefaultParameters)
+                    ? allDefaultParameters
+                    : []
+                "
+                :interval="clock.interval"
+                :timezone="timezoneVal(clock)"
+                :selected-tab="selectedTab"
+                @cancel="selectedClock = null"
+                @confirm="createClock"
+              /> -->
+
+              <!-- <div v-show="selectedTab === 0">
                 <ClockForm
                   :flow-group-clocks="flowGroupClocks"
                   :clock="clock"
@@ -486,7 +467,7 @@ export default {
                   disable-edit
                   allow-reset
                 />
-              </div>
+              </div> -->
             </div>
 
             <div v-else key="2" style="height: 100%;">


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Should resolve #1061 

This moves the `DictInput` component and its computed prop and methods from the `Schedules` component into the `ClockForm` component