### PR TITLE
tree shaking highlightjs dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 
 ### Bugfixes
 
+- Removed unnecessary dependency preventing us from tree shaking highlightjs - [#1108](https://github.com/PrefectHQ/ui/pull/1108) 
 - Adds a try/catch block when deleting a membership in the removeUser method - [#1094](https://github.com/PrefectHQ/ui/pull/1094)
 
 - Internal: update CircleCI config slack orb (add `@` to mentions) - [#1053](https://github.com/PrefectHQ/ui/pull/1053)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "remark-autolink-headings": "^6.0.1",
     "remark-breaks": "^2.0.2",
     "remark-gfm": "^1.0.0",
-    "remark-highlight.js": "^6.0.0",
     "remark-html": "^13.0.1",
     "remark-slug": "^6.0.0",
     "velocity-animate": ">=1.5.2",

--- a/src/utils/markdownParser.js
+++ b/src/utils/markdownParser.js
@@ -2,7 +2,6 @@ import remark from 'remark'
 import html from 'remark-html'
 import breaks from 'remark-breaks'
 import slug from 'remark-slug'
-import highlight from 'remark-highlight.js'
 import headings from 'remark-autolink-headings'
 import gfm from 'remark-gfm'
 import all from 'mdast-util-to-hast/lib/all'
@@ -16,7 +15,6 @@ export function parser(md) {
     remark()
       .use(breaks)
       .use(slug)
-      .use(highlight)
       .use(headings, {
         content: {
           type: 'text',
@@ -39,7 +37,6 @@ export function artifact_parser(md) {
     remark()
       .use(breaks)
       .use(slug)
-      .use(highlight)
       .use(gfm)
       .use(html, {
         handlers: {


### PR DESCRIPTION

PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
This package's use of Highlight.js was over double the size of the next biggest dependency. Removing this dependency and the 3 lines from markdownParser I was able to bring down the highlightjs bundle size from 1.3M to 77.5K! 

While at first glance, I expected this to have an impact on user experience, I cannot find an instance where this change actually effected what the user sees. I confirmed the "describe" component used in a flow's readme, as well as the artifacts tab of a flow-run. Markdown entry and parsing seems uneffected by this change.