### PR TITLE
Bugfix: Set min-width in titlebars to account for shorter names

### DIFF
--- a/src/pages/Flow/Flow.vue
+++ b/src/pages/Flow/Flow.vue
@@ -271,10 +271,9 @@ export default {
       >
         <div
           v-if="flowGroup"
-          class="text-truncate"
+          class="text-truncate minTitleWidth"
           :style="{
             width: selectedFlow.name.length + 'ch',
-            minWidth: '10vw',
             maxWidth: titleBarMaxWidth
           }"
         >
@@ -544,3 +543,9 @@ export default {
     </v-bottom-navigation>
   </v-sheet>
 </template>
+
+<style>
+.minTitleWidth {
+  min-width: 20vw;
+}
+</style>

--- a/src/pages/Flow/Flow.vue
+++ b/src/pages/Flow/Flow.vue
@@ -274,6 +274,7 @@ export default {
           class="text-truncate"
           :style="{
             width: selectedFlow.name.length + 'ch',
+            minWidth: '10vw',
             maxWidth: titleBarMaxWidth
           }"
         >

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -247,6 +247,7 @@ export default {
         :style="{
           display: $vuetify.breakpoint.smAndDown ? 'inline' : 'block',
           width: flowRunNameLength + 'ch',
+          minWidth: '10vw',
           maxWidth: titleBarMaxWidth
         }"
       >

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -244,10 +244,10 @@ export default {
     <SubPageNav icon="pi-flow-run" page-type="Flow Run">
       <span
         slot="page-title"
+        class="minTitleWidth"
         :style="{
           display: $vuetify.breakpoint.smAndDown ? 'inline' : 'block',
           width: flowRunNameLength + 'ch',
-          minWidth: '10vw',
           maxWidth: titleBarMaxWidth
         }"
       >
@@ -433,5 +433,9 @@ export default {
 .v-badge--inline .v-badge__badge,
 .v-badge--inline .v-badge__wrapper {
   margin: 5px;
+}
+
+.minTitleWidth {
+  min-width: 20vw;
 }
 </style>

--- a/src/pages/TaskRun/TaskRun.vue
+++ b/src/pages/TaskRun/TaskRun.vue
@@ -212,6 +212,7 @@ export default {
         :style="{
           display: $vuetify.breakpoint.smAndDown ? 'inline' : 'block',
           width: taskRunNameLength + 'ch',
+          minWidth: '10vw',
           maxWidth: titleBarMaxWidth
         }"
       >

--- a/src/pages/TaskRun/TaskRun.vue
+++ b/src/pages/TaskRun/TaskRun.vue
@@ -209,10 +209,10 @@ export default {
     <SubPageNav icon="pi-task-run" page-type="Task Run">
       <span
         slot="page-title"
+        class="minTitleWidth"
         :style="{
           display: $vuetify.breakpoint.smAndDown ? 'inline' : 'block',
           width: taskRunNameLength + 'ch',
-          minWidth: '10vw',
           maxWidth: titleBarMaxWidth
         }"
       >
@@ -383,5 +383,9 @@ export default {
 .v-badge--inline .v-badge__badge,
 .v-badge--inline .v-badge__wrapper {
   margin: 5px;
+}
+
+.minTitleWidth {
+  min-width: 20vw;
 }
 </style>


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Sets a min-width of 10vw in the Flow, Flow Run, and Task Run titlebars to not cut off shorter names