### PR TITLE
Performance: Removed watchers and/or increased watchers specificity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -177,13 +177,9 @@ export default {
         this.$apollo.queries.flows.refresh()
       }
     },
-    async $route(new_route, old_route) {
-      if (
-        new_route?.params?.tenant &&
-        new_route?.params?.tenant !== old_route?.params?.tenant &&
-        this.tenant?.slug !== new_route.params.tenant
-      ) {
-        await this.setCurrentTenant(new_route.params.tenant)
+    '$route.params.tenant'(value, previous) {
+      if (value !== previous && value !== this.tenant?.slug) {
+        this.setCurrentTenant(value)
       }
     },
     isAuthorized(value) {

--- a/src/components/ConfirmDialog.vue
+++ b/src/components/ConfirmDialog.vue
@@ -74,15 +74,14 @@ export default {
       default: ''
     }
   },
-  data() {
-    return {
-      internalValue: this.value
-    }
-  },
-  watch: {
-    value(val) {
-      // Keep the internal state of the alert on par with the value prop.
-      this.internalValue = val
+  computed: {
+    internalValue: {
+      get() {
+        return this.value
+      },
+      set(value) {
+        this.$emit('input', value)
+      }
     }
   },
   methods: {
@@ -92,16 +91,9 @@ export default {
     handleCancel() {
       this.internalValue = false
       this.$emit('cancel')
-      this.emitInternalValue()
     },
     handleConfirm() {
       this.$emit('confirm')
-      this.emitInternalValue()
-    },
-    // Propagate the internal value to the component's parent.
-    // This method is what allows us to set v-model on this component.
-    handleInput() {
-      this.emitInternalValue()
     }
   }
 }
@@ -112,7 +104,6 @@ export default {
     :value="internalValue"
     v-bind="dialogProps"
     :width="width"
-    @input="handleInput"
     @click:outside="handleCancel"
     @keydown.esc="handleCancel"
   >

--- a/src/components/NavTabBar.vue
+++ b/src/components/NavTabBar.vue
@@ -23,7 +23,6 @@ export default {
   },
   data() {
     return {
-      tab: this.getTab(),
       pageScrolled: false
     }
   },
@@ -33,45 +32,35 @@ export default {
     },
     secondaryTabs() {
       return this.tabs.filter(tab => !tab.hidden && tab.align === 'right')
-    }
-  },
-  watch: {
-    tab(val) {
-      if (this.paths) return
-      let query = {}
-      if (val) {
-        if (this.$route.params.id) {
-          query[val] = this.$route.params.id // schematic uses this
+    },
+    tab: {
+      get() {
+        const route = this.tabs.find(
+          t => t.to?.path == this.$route.path || t.to?.name == this.$route.name
+        )
+
+        if (Object.keys(this.$route.query).length != 0) {
+          return Object.keys(this.$route.query)[0]
+        } else if (route) {
+          return route.to.path || route.to.name
         }
-        if (this.$route.query.version) {
+
+        return 'overview'
+      },
+      set(value) {
+        if (this.paths) return
+
+        const query = { [value]: null }
+
+        if (value && this.$route.query.version) {
           query.version = this.$route.query.version
         }
-        query[val] = ''
+
+        this.$router.replace({ query }).catch()
       }
-      this.$router
-        .replace({
-          query: query
-        })
-        .catch(e => e)
-    },
-    $route() {
-      this.tab = this.getTab()
     }
   },
   methods: {
-    getTab() {
-      const route = this.tabs.find(
-        t => t.to?.path == this.$route.path || t.to?.name == this.$route.name
-      )
-
-      if (Object.keys(this.$route.query).length != 0) {
-        return Object.keys(this.$route.query)[0]
-      } else if (route) {
-        return route.to.path || route.to.name
-      }
-
-      return 'overview'
-    },
     scrolled() {
       this.pageScrolled = window.scrollY > 30
     }

--- a/src/components/Plans/PlanSelectionForm.vue
+++ b/src/components/Plans/PlanSelectionForm.vue
@@ -56,13 +56,6 @@ export default {
       return title
     }
   },
-  watch: {
-    step(val) {
-      if (val == 'select-card') {
-        this.getTenants()
-      }
-    }
-  },
   mounted() {
     this.getTenants()
   },
@@ -100,24 +93,33 @@ export default {
     },
     handleConfirm(sourceId) {
       this.paymentSource = sourceId
-      this.step = 'confirm'
+      this.setStep('confirm')
     },
     handleNext() {
       if (this.paymentSource == 'new') {
-        this.step = 'add-card'
+        this.setStep('add-card')
       } else {
-        this.step = 'confirm'
+        this.setStep('confirm')
       }
     },
     selectPayment(id) {
       this.paymentSource = id
     },
+    setStep(step) {
+      this.step = step
+
+      if (step == 'select-card') {
+        this.getTenants()
+      }
+    },
     async handleSubmit() {
       await this.updatePlan()
       if (!this.error) {
         this.$emit('complete')
-        this.step = 'complete'
-      } else this.step = 'error'
+        this.setStep('complete')
+      } else {
+        this.setStep('error')
+      }
     }
   }
 }
@@ -140,7 +142,7 @@ export default {
         >
           <div
             class="d-inline-block text-subtitle-1 font-weight-light mx-auto cursor-pointer mt-4 h-auto"
-            @click="step = 'select-card'"
+            @click="setStep('select-card')"
           >
             <v-icon color="blue-grey">chevron_left</v-icon>
             Choose an existing method instead
@@ -327,7 +329,7 @@ export default {
         >
           <div
             class="d-inline-block text-subtitle-1 font-weight-light cursor-pointer mt-4 h-auto"
-            @click="step = 'select-card'"
+            @click="setStep('select-card')"
           >
             <v-icon color="blue-grey">chevron_left</v-icon>
             Change payment method

--- a/src/components/Schematics/Preview-Tile.vue
+++ b/src/components/Schematics/Preview-Tile.vue
@@ -37,22 +37,24 @@ export default {
     }
   },
   watch: {
-    $route(val) {
-      // this.search = val.query.schematic
-      if (!val.query.schematic) {
+    '$route.query.schematic'(val) {
+      if (!val) {
         this.task = null
         this.searchInput = null
-        return
+      } else {
+        this.updatePreview()
       }
-      this.updatePreview()
     },
     searchInput(val) {
       let selected = this.options.find(opt => opt.name == val)
       if (selected) this.handleSelect(selected)
     },
     tasks() {
-      if (!this.$route.query.schematic) return (this.task = null)
-      this.updatePreview()
+      if (!this.$route.query.schematic) {
+        this.task = null
+      } else {
+        this.updatePreview()
+      }
     }
   },
   mounted() {

--- a/src/layouts/ManagementLayout.vue
+++ b/src/layouts/ManagementLayout.vue
@@ -16,14 +16,14 @@ export default {
       required: false
     }
   },
-  data() {
-    return {
-      showPage: this.show || false
-    }
-  },
-  watch: {
-    show(val) {
-      this.showPage = val
+  computed: {
+    showPage: {
+      get() {
+        return this.show
+      },
+      set(value) {
+        this.$emit('update:show', value)
+      }
     }
   },
   mounted() {

--- a/src/pages/Agents/AgentFlowRunHistory.vue
+++ b/src/pages/Agents/AgentFlowRunHistory.vue
@@ -29,14 +29,6 @@ export default {
       return 5000
     }
   },
-  watch: {
-    flowRuns() {
-      if (this.tooltip) {
-        let exists = this.flowRuns.find(f => f.id == this.tooltip.data.id)
-        this.tooltip = exists ? this.tooltip : null
-      }
-    }
-  },
   mounted() {
     if (this.pollInterval > 0) {
       this.$apollo.queries.flowRuns.startPolling(this.pollInterval)

--- a/src/pages/Dashboard/Dashboard.vue
+++ b/src/pages/Dashboard/Dashboard.vue
@@ -104,8 +104,7 @@ export default {
       loadedTiles: 0,
       numberOfTiles: 10,
       projectId: this.$route.params.id,
-      refreshTimeout: null,
-      tab: this.getTab()
+      refreshTimeout: null
     }
   },
   computed: {
@@ -122,6 +121,12 @@ export default {
     },
     includeProjects() {
       return this.tab != 'automations' && this.tab != 'calendar'
+    },
+    tab() {
+      if ('flows' in this.$route.query) return 'flows'
+      if ('calendar' in this.$route.query) return 'calendar'
+      if ('automations' in this.$route.query) return 'automations'
+      return 'overview'
     }
   },
   watch: {
@@ -132,9 +137,6 @@ export default {
         this.refresh()
         clearTimeout(this.refreshTimeout)
       }, 3000)
-    },
-    $route() {
-      this.tab = this.getTab()
     },
     'tenant.id'(val, old) {
       if (val && val !== old) {
@@ -170,12 +172,6 @@ export default {
     handleProjectSelect(val) {
       this.projectId = val
       if (this.projectId?.length > 0) this.activateProject(this.projectId)
-    },
-    getTab() {
-      if ('flows' in this.$route.query) return 'flows'
-      if ('calendar' in this.$route.query) return 'calendar'
-      if ('automations' in this.$route.query) return 'automations'
-      return 'overview'
     },
     refresh() {
       let start
@@ -432,7 +428,11 @@ export default {
     </v-tabs-items>
 
     <v-bottom-navigation v-if="$vuetify.breakpoint.smAndDown" app fixed>
-      <v-btn v-for="tb in tabs" :key="tb.target" @click="tab = tb.target">
+      <v-btn
+        v-for="tb in tabs"
+        :key="tb.target"
+        @click="$router.replace({ query: { [tb.target]: null } })"
+      >
         {{ tb.name }}
         <v-icon>{{ tb.icon }}</v-icon>
       </v-btn>

--- a/src/pages/Dashboard/FlowRunHistory-Tile.vue
+++ b/src/pages/Dashboard/FlowRunHistory-Tile.vue
@@ -27,14 +27,6 @@ export default {
       return this.loadingKey > 0
     }
   },
-  watch: {
-    flowRuns() {
-      if (this.tooltip) {
-        let exists = this.flowRuns.find(f => f.id == this.tooltip.data.id)
-        this.tooltip = exists ? this.tooltip : null
-      }
-    }
-  },
   apollo: {
     flowRuns: {
       query: require('@/graphql/Dashboard/timeline-flow-runs.gql'),

--- a/src/pages/Dashboard/Project-Selector.vue
+++ b/src/pages/Dashboard/Project-Selector.vue
@@ -70,19 +70,15 @@ export default {
           this.$route.params.id === '' ? null : this.$route.params.id
       }
     },
-    $route(val) {
-      if (val.params && !('id' in val.params) && this.projectId !== null) {
+    '$route.params.id'(val) {
+      if (!val && this.projectId !== null) {
         this.projectSelect = null
         this.projectId = null
         this.$emit('project-select', null)
-      } else if (
-        val.params &&
-        'id' in val.params &&
-        this.projectId !== val.params.id
-      ) {
+      } else if (val && this.projectId !== val) {
         // This will ensure the normal emit and project id setting
         // happens in the watcher above
-        this.projectSelect = val.params.id
+        this.projectSelect = val
       }
     }
   },

--- a/src/pages/Flow/Actions.vue
+++ b/src/pages/Flow/Actions.vue
@@ -77,9 +77,9 @@ export default {
     }
   },
   watch: {
-    $route(val) {
-      if (this.selectedVersion == val.query?.version) return
-      this.selectedVersion = +val.query.version || null
+    '$route.query.version'(val) {
+      if (this.selectedVersion == val) return
+      this.selectedVersion = +val || null
     }
   },
   mounted() {

--- a/src/pages/Flow/Flow.vue
+++ b/src/pages/Flow/Flow.vue
@@ -61,7 +61,6 @@ export default {
   data() {
     return {
       loadingKey: 0,
-      tab: this.getTab(),
       tabs: [
         {
           name: 'Overview',
@@ -98,11 +97,6 @@ export default {
           target: 'automations',
           icon: 'fad fa-random'
         },
-        // {
-        //   name: 'Versions',
-        //   target: 'versions',
-        //   icon: 'loop'
-        // },
         {
           name: 'Run',
           target: 'run',
@@ -165,61 +159,33 @@ export default {
         return '40vw'
       }
       return '30vw'
+    },
+    tab: {
+      get(){
+      const keys = Object.keys(this.$route.query ?? {})
+      if (keys.length > 0 && this.tabs?.find(tab => tab.target == keys[0])) {
+        return keys[0]
+      }
+
+      return 'overview'
+      },
+      set(value){
+        this.$router.replace({query: { [value]: null }})
+      }
     }
   },
   watch: {
-    $route() {
-      this.tab = this.getTab()
-
-      if (this.$route.name == 'flow') {
+    'this.$route.name'(val){
+      if (val == 'flow') {
         this.activateFlow(this.$route.params.id)
-      }
-    },
-    tab(val) {
-      let query = { ...this.$route.query }
-      switch (val) {
-        case 'schematic':
-          query = 'schematic'
-          break
-        case 'runs':
-          query = 'runs'
-          break
-        case 'tasks':
-          query = 'tasks'
-          break
-        case 'description':
-          query = 'description'
-          break
-        case 'versions':
-          query = 'versions'
-          break
-        case 'automations':
-          query = 'automations'
-          break
-        case 'run':
-          query = 'run'
-          break
-        case 'settings':
-          query = 'settings'
-          break
-        default:
-          break
       }
     }
   },
   async beforeMount() {
-    await this.activateFlow(this.$route.params.id)
-    this.tab = this.getTab()
+  await this.activateFlow(this.$route.params.id)
   },
   methods: {
-    ...mapActions('data', ['activateFlow', 'resetActiveData']),
-    getTab() {
-      if (Object.keys(this.$route.query).length != 0) {
-        let target = Object.keys(this.$route.query)[0]
-        if (this.tabs?.find(tab => tab.target == target)) return target
-      }
-      return 'overview'
-    }
+    ...mapActions('data', ['activateFlow', 'resetActiveData'])
   },
   apollo: {
     flowGroup: {

--- a/src/pages/Flow/FlowRunHistory-Tile.vue
+++ b/src/pages/Flow/FlowRunHistory-Tile.vue
@@ -34,12 +34,6 @@ export default {
     }
   },
   watch: {
-    flowRuns() {
-      if (this.tooltip) {
-        let exists = this.flowRuns.find(f => f.id == this.tooltip.data.id)
-        this.tooltip = exists ? this.tooltip : null
-      }
-    },
     watch: {
       flow() {
         this.$apollo.queries.flowRuns.stopPolling()

--- a/src/pages/FlowRun/FlowRun.vue
+++ b/src/pages/FlowRun/FlowRun.vue
@@ -57,7 +57,6 @@ export default {
       error: false,
       flowRunNameLoading: false,
       loadingKey: 0,
-      tab: this.getTab(),
       tabs: [
         {
           name: 'Overview',
@@ -109,44 +108,23 @@ export default {
         return '40vw'
       }
       return '30vw'
-    }
-  },
-  watch: {
-    $route() {
-      this.tab = this.getTab()
     },
-    tab(val) {
-      let query = { ...this.$route.query }
-      switch (val) {
-        case 'schematic':
-          query = 'schematic'
-          break
-        case 'logs':
-          query = 'logId'
-          break
-        case 'chart':
-          query = { chart: '' }
-          break
-        case 'artifacts':
-          /* eslint-disable-next-line */
-          query = 'artifacts'
-          break
-        default:
-          break
+    tab: {
+      get() {
+        const keys = Object.keys(this.$route.query ?? {})
+        if (keys.length > 0 && this.tabs?.find(tab => tab.target == keys[0])) {
+          return keys[0]
+        }
+
+        return 'overview'
+      },
+      set(value) {
+        this.$router.replace({ query: { [value]: null } })
       }
     }
-  },
-  beforeMount() {
-    this.tab = this.getTab()
   },
   methods: {
     ...mapActions('alert', ['setAlert']),
-    getTab() {
-      if (Object.keys(this.$route.query).length != 0) {
-        return Object.keys(this.$route.query)[0]
-      }
-      return 'overview'
-    },
     parseMarkdown(md) {
       return parser(md)
     },

--- a/src/pages/Task/Dependencies-Tile.vue
+++ b/src/pages/Task/Dependencies-Tile.vue
@@ -51,21 +51,22 @@ export default {
     }
   },
   watch: {
-    $route(val) {
-      if (!val.query.schematic) return (this.task = null)
-      this.task = this.tasks.find(
-        task => task.id == this.$route.query.schematic
-      )
+    '$route.query.schematic'(val) {
+      this.setTask(val)
     },
     tasks() {
-      if (!this.$route.query.schematic) return (this.task = null)
-
-      this.task = this.tasks.find(
-        task => task.id == this.$route.query.schematic
-      )
+      this.setTask(this.$route.query.schematic)
     }
   },
-  methods: {}
+  methods: {
+    setTask(id) {
+      if (!id) {
+        this.task = null
+      } else {
+        this.task = this.tasks.find(task => task.id == id)
+      }
+    }
+  }
 }
 </script>
 

--- a/src/pages/Task/Task.vue
+++ b/src/pages/Task/Task.vue
@@ -38,7 +38,6 @@ export default {
   data() {
     return {
       loading: 0,
-      tab: this.getTab(),
       tabs: [
         {
           name: 'Overview',
@@ -83,28 +82,25 @@ export default {
     upstreamCount() {
       if (!this.task) return null
       return this.task.upstream_edges.length
+    },
+    tab: {
+      get() {
+        const keys = Object.keys(this.$route.query ?? {})
+        if (keys.length > 0 && this.tabs?.find(tab => tab.target == keys[0])) {
+          return keys[0]
+        }
+
+        return 'overview'
+      },
+      set(value) {
+        this.$router.replace({ query: { [value]: null } })
+      }
     }
   },
   watch: {
-    $route() {
-      this.tab = this.getTab()
-
-      if (this.$route.name == 'task') {
+    '$route.name'(val) {
+      if (val == 'task') {
         this.activateTask(this.$route.params.id)
-      }
-    },
-    tab(val) {
-      let query = { ...this.$route.query }
-      switch (val) {
-        case 'schematic':
-          query = 'schematic'
-          break
-        case 'runs':
-          /* eslint-disable-next-line */
-          query = 'runs'
-          break
-        default:
-          break
       }
     },
     task(val) {
@@ -113,17 +109,9 @@ export default {
   },
   async beforeMount() {
     await this.activateTask(this.$route.params.id)
-    this.tab = this.getTab()
   },
   methods: {
-    ...mapActions('data', ['activateTask', 'resetActiveData']),
-    getTab() {
-      if (Object.keys(this.$route.query).length != 0) {
-        let target = Object.keys(this.$route.query)[0]
-        if (this.tabs?.find(tab => tab.target == target)) return target
-      }
-      return 'overview'
-    }
+    ...mapActions('data', ['activateTask', 'resetActiveData'])
   },
   apollo: {
     task: {
@@ -284,11 +272,6 @@ export default {
         Runs
         <v-icon>pi-task-run</v-icon>
       </v-btn>
-
-      <!-- <v-btn disabled @click="tab = 'analytics'">
-        Analytics
-        <v-icon>insert_chart_outlined</v-icon>
-      </v-btn> -->
     </v-bottom-navigation>
   </v-sheet>
 </template>

--- a/src/pages/TaskRun/TaskRun.vue
+++ b/src/pages/TaskRun/TaskRun.vue
@@ -52,7 +52,6 @@ export default {
   data() {
     return {
       loading: 0,
-      tab: this.getTab(),
       taskRunNameLoading: false
     }
   },
@@ -110,12 +109,22 @@ export default {
         return '40vw'
       }
       return '30vw'
+    },
+    tab: {
+      get() {
+        const keys = Object.keys(this.$route.query ?? {})
+        if (keys.length > 0 && this.tabs?.find(tab => tab.target == keys[0])) {
+          return keys[0]
+        }
+
+        return 'overview'
+      },
+      set(value) {
+        this.$router.replace({ query: { [value]: null } })
+      }
     }
   },
   watch: {
-    $route() {
-      this.tab = this.getTab()
-    },
     taskRun(val, prevVal) {
       if (val === 'not-found') this.$router.push({ name: 'not-found' })
       if (!val || val?.id == prevVal?.id) return
@@ -133,12 +142,6 @@ export default {
   },
   methods: {
     ...mapActions('alert', ['setAlert']),
-    getTab() {
-      if (Object.keys(this.$route.query).length != 0) {
-        return Object.keys(this.$route.query)[0]
-      }
-      return 'overview'
-    },
     parseMarkdown(md) {
       return parser(md)
     },


### PR DESCRIPTION
Watchers can be expensive, especially when the object is a large array, or the watcher is "deep".  Even inexpensive watchers can become create performance issues when you're dealing with a large number of the components within a view.  This PR outright removes many watchers. Where watchers couldn't be removed, I was still able to increase the watchers specificity.   For example, watching `$route` only to be checking a very specific param within the handler. It's better to just watch the specific param by watching `$route.params.tenant` for example. Some watchers were replaced with computed variables to follow vue's suggestion that watchers be used for "side-effects of changing data". There are also some cases where I was able to use the watcher API to only temporarily watch a property instead of continuing to watch for the lifetime of the component. Together these changes should help improve performance of the system and also improve the clarity of the intent of watchers within these components.