### PR TITLE
Feature: Add loading state to RestartDialog

### DIFF
--- a/src/pages/FlowRun/Actions.vue
+++ b/src/pages/FlowRun/Actions.vue
@@ -183,7 +183,9 @@ export default {
             depressed
             style="height: 46px;"
             small
-            :disabled="!hasPermission('update', 'run') || !canRestart"
+            :disabled="
+              !hasPermission('update', 'run') || !canRestart || restartDialog
+            "
             color="info"
             @click="handleRestartClick"
           >

--- a/src/pages/FlowRun/Restart-Dialog.vue
+++ b/src/pages/FlowRun/Restart-Dialog.vue
@@ -18,7 +18,8 @@ export default {
   },
   data() {
     return {
-      error: false
+      error: false,
+      loading: false
     }
   },
   computed: {
@@ -49,7 +50,7 @@ export default {
     },
     async restart() {
       try {
-        this.cancel()
+        this.loading = true
 
         this.writeLogs()
 
@@ -103,6 +104,9 @@ export default {
           })
 
           if (data?.set_flow_run_states) {
+            this.loading = false
+            this.cancel()
+
             this.setAlert({
               alertShow: true,
               alertMessage: 'Flow run restarted.',
@@ -120,6 +124,8 @@ export default {
       }
 
       if (this.error === true) {
+        this.loading = false
+        this.cancel()
         this.setAlert({
           alertShow: true,
           alertMessage:
@@ -180,7 +186,12 @@ export default {
     <v-card-actions>
       <v-spacer></v-spacer>
 
-      <v-btn :disabled="!isEligibleToRestart" color="primary" @click="restart">
+      <v-btn
+        :disabled="!isEligibleToRestart || loading"
+        color="primary"
+        :loading="loading"
+        @click="restart"
+      >
         Confirm
       </v-btn>
 


### PR DESCRIPTION
PR Checklist:

- [ ] add a short description of what's changed to the top of the `CHANGELOG.md`
- [ ] add/update tests (or don't, for reasons explained below)

## Describe this PR
Adds a loading and disabled state when restarting flow runs 