### PR TITLE
Make request credentials forwarding customizable

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,12 @@ VUE_APP_LOG_ROCKET_PUBLIC_ID=qetfiw/cloud-web-ui
 VUE_APP_AUTH0_DOMAIN=login.prefect.io
 VUE_APP_AUTH0_PUBLIC_CLIENT_ID=z8iBknuNYsEHh61it7ihD5EVvMsG9920
 
+# The value to set for the `credentials` attribute when making requests to the
+# server. Allows values are `omit`, `same-origin` and `include`. See
+# https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials for more
+# information.
+VUE_APP_REQUEST_CREDENTIALS_MODE=same-origin
+
 VUE_APP_OKTA_DOMAIN=universal.prefect.io
 VUE_APP_PUBLIC_CLIENT_ID=0oa9jg1pkaNp0GV6t1d6
 VUE_APP_PUBLIC_ISSUER=https://universal.prefect.io/oauth2/aus9ej78aeaYy8Lcf1d6

--- a/Changelog.md
+++ b/Changelog.md
@@ -85,7 +85,7 @@
 ### Features and Improvements
 
 - Add a copy method to task run result locations - [#1033](https://github.com/PrefectHQ/ui/pull/1033)
-- Route to task run page on timeline click - [#1024](<https://github.com/PrefectHQ/ui/pull/1024>
+- Route to task run page on timeline click - [#1024](https://github.com/PrefectHQ/ui/pull/1024)
 - Fix artifact title overlap - [#1032](https://github.com/PrefectHQ/ui/pull/1032)
 - Increase default number of flows shown in the flow table - [#1027](https://github.com/PrefectHQ/ui/pull/1027)
 - Remove global max width on dashboard etc screens - [#1026](https://github.com/PrefectHQ/ui/pull/1026)

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ### Features and Improvements
 
-- None
+- Allow the UI to include credentials when making requests to the server - [#1149](https://github.com/PrefectHQ/ui/pull/1149)
 
 ### Bugfixes
 
@@ -85,7 +85,7 @@
 ### Features and Improvements
 
 - Add a copy method to task run result locations - [#1033](https://github.com/PrefectHQ/ui/pull/1033)
-- Route to task run page on timeline click - [#1024](https://github.com/PrefectHQ/ui/pull/1024
+- Route to task run page on timeline click - [#1024](<https://github.com/PrefectHQ/ui/pull/1024>
 - Fix artifact title overlap - [#1032](https://github.com/PrefectHQ/ui/pull/1032)
 - Increase default number of flows shown in the flow table - [#1027](https://github.com/PrefectHQ/ui/pull/1027)
 - Remove global max width on dashboard etc screens - [#1026](https://github.com/PrefectHQ/ui/pull/1026)
@@ -714,7 +714,7 @@
 - Add section to flow details for `flow.run_config` if not null, otherwise display `flow.environment` [#307](https://github.com/PrefectHQ/ui/pull/307)
 - Enable restart from cancelled and update restart from failed [#234](https://github.com/PrefectHQ/ui/pull/234)
 - Add unit tests for the authNavGuard middleware [#266](https://github.com/PrefectHQ/ui/pull/266)
-- Update label edit and label warning to use flow run labels (#300)[https://github.com/PrefectHQ/ui/pull/300]
+- Update label edit and label warning to use flow run labels [#300](https://github.com/PrefectHQ/ui/pull/300)
 - Display task run names on flow run page and task run page [#302](https://github.com/PrefectHQ/ui/pull/302)
 
 ### Bugfixes
@@ -978,7 +978,7 @@
 
 ## 2020-08-18
 
-### Hello, world!
+### Hello, world
 
 - Add a default parameters page in flow settings[#24](https://github.com/PrefectHQ/ui/pull/24)
 - Switch the errors tile to become a failed tasks tile and add better timeout error handling [#6](https://github.com/PrefectHQ/prefect-ui/pull/6)

--- a/Changelog.md
+++ b/Changelog.md
@@ -978,7 +978,7 @@
 
 ## 2020-08-18
 
-### Hello, world
+### Hello, world!
 
 - Add a default parameters page in flow settings[#24](https://github.com/PrefectHQ/ui/pull/24)
 - Switch the errors tile to become a failed tasks tile and add better timeout error handling [#6](https://github.com/PrefectHQ/prefect-ui/pull/6)

--- a/src/vue-apollo.js
+++ b/src/vue-apollo.js
@@ -32,13 +32,19 @@ function notExpired(expiry) {
 let errors = 0,
   apiErrors = 0
 
+const { VUE_APP_REQUEST_CREDENTIALS_MODE: credentials } = process.env
+
 const batchLink = new BatchHttpLink({
   batchMax: 25,
   batchInterval: 2000,
+  credentials,
   uri: () => store.getters['api/url']
 })
 
-const httpLink = new HttpLink({ uri: () => store.getters['api/url'] })
+const httpLink = new HttpLink({
+  credentials,
+  uri: () => store.getters['api/url']
+})
 
 // Resets the cache and stops requests if
 // the backend has changed

--- a/tests/unit/vue-apollo.spec.js
+++ b/tests/unit/vue-apollo.spec.js
@@ -1,0 +1,21 @@
+describe('VueApollo', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('does not include credentials by default', () => {
+    const { defaultOptions } = require('@/vue-apollo')
+    const { link } = defaultOptions
+
+    expect(link.credentials).toEqual(undefined)
+  })
+
+  it('includes credentials when specifically indicated', () => {
+    process.env.VUE_APP_REQUEST_CREDENTIALS_MODE = 'include'
+
+    const { defaultOptions } = require('@/vue-apollo')
+    const { link } = defaultOptions
+
+    expect(link.credentials).toEqual(undefined)
+  })
+})


### PR DESCRIPTION
PR Checklist:

- [x] add a short description of what's changed to the top of the `CHANGELOG.md`
- [x] add/update tests (or don't, for reasons explained below)

## Describe this PR

When running Prefect on premise, it's sometimes necessary for the UI to
forward authentication cookies (e.g. when the authentication layer is provided
by a reverse proxy and not the Prefect server). This change allows for the UI
to be customized by providing an extra env variable named
`VUE_APP_REQUEST_CREDENTIALS_MODE`, which will cause the UI to forward cookies
to the Apollo server if the variable is set with `include` as its value. If the
variable is left unset, the behaviour is the same as before.