### PR TITLE
Cut Changelog ahead of 2021-12-15 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,14 @@
 # Changelog
+
+## 2021-12-15
+
+- BugFix: added missing icon for help getting-started [`#1164`](https://github.com/PrefectHQ/ui/pull/1164)
+- Bugfix: Check tenant is in route params tenant before calling setCurrentTenant [`#1174`](https://github.com/PrefectHQ/ui/pull/1174)
+- Bugfix: Send to sales for more users [`#1172`](https://github.com/PrefectHQ/ui/pull/1172)
+
 ## 2021-12-14a
 
+- Changelog: Cut hotfix changelog [`#1165`](https://github.com/PrefectHQ/ui/pull/1165)
 - HOTFIX: Remove intersection observers from Members, Invitations-Table, Members-Table components [`#1162`](https://github.com/PrefectHQ/ui/pull/1162)
 - HOTFIX: Remove intersection observer on notifications group component [`#1163`](https://github.com/PrefectHQ/ui/pull/1163)
 - HOTFIX: Rolling back watcher change [`#1158`](https://github.com/PrefectHQ/ui/pull/1158)


### PR DESCRIPTION
# Changelog

## 2021-12-15

- BugFix: added missing icon for help getting-started [`#1164`](https://github.com/PrefectHQ/ui/pull/1164)
- Bugfix: Check tenant is in route params tenant before calling setCurrentTenant [`#1174`](https://github.com/PrefectHQ/ui/pull/1174)
- Bugfix: Send to sales for more users [`#1172`](https://github.com/PrefectHQ/ui/pull/1172)
