### PR TITLE
Admin: Add input sanitizer as default for log rocket

### DIFF
--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -408,6 +408,7 @@ export default {
             <v-row>
               <v-col cols="12" md="8" class="pb-0">
                 <v-autocomplete
+                  data-public
                   v-if="canEdit && !versionGroupIdProp"
                   id="item"
                   v-model="versionGroupIdSelect"

--- a/src/components/CustomInputs/KeyValueInput.vue
+++ b/src/components/CustomInputs/KeyValueInput.vue
@@ -12,6 +12,7 @@
     />
     <template v-if="showTypes && hasTypes">
       <v-select
+        data-public
         v-model="selectedType"
         :items="[emptyTypeOption, ...types]"
         label="Type"

--- a/src/components/DateTime.vue
+++ b/src/components/DateTime.vue
@@ -224,6 +224,7 @@ export default {
               <v-row>
                 <v-col cols="4">
                   <v-autocomplete
+                    data-public
                     v-model="timeHr"
                     hide-details
                     label="Hour"
@@ -234,6 +235,7 @@ export default {
                 </v-col>
                 <v-col cols="4">
                   <v-autocomplete
+                    data-public
                     v-model="timeMin"
                     hide-details
                     label="Minute"
@@ -244,6 +246,7 @@ export default {
                 </v-col>
                 <v-col cols="4">
                   <v-autocomplete
+                    data-public
                     v-model="timeAmPm"
                     hide-details
                     label="AM/PM"

--- a/src/components/GlobalSearchBar/GlobalSearch.vue
+++ b/src/components/GlobalSearchBar/GlobalSearch.vue
@@ -277,6 +277,7 @@ export default {
       :class="{ active: active, fixed: $vuetify.breakpoint.xsOnly }"
     >
       <v-autocomplete
+        data-public
         v-if="active"
         ref="global-search"
         v-model="model"

--- a/src/components/LogsCard/FilterMenu.vue
+++ b/src/components/LogsCard/FilterMenu.vue
@@ -244,6 +244,7 @@ export default {
             <v-row v-if="dateFromInput" dense>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeFromInputHr"
                   class="ma-0"
                   dense
@@ -258,6 +259,7 @@ export default {
               </v-col>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeFromInputMin"
                   class="ma-0"
                   dense
@@ -272,6 +274,7 @@ export default {
               </v-col>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeFromInputSec"
                   class="ma-0"
                   dense
@@ -286,6 +289,7 @@ export default {
               </v-col>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeFromInputAmPm"
                   class="ma-0"
                   dense
@@ -332,6 +336,7 @@ export default {
             <v-row v-if="dateToInput" dense>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeToInputHr"
                   class="ma-0"
                   dense
@@ -346,6 +351,7 @@ export default {
               </v-col>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeToInputMin"
                   class="ma-0"
                   dense
@@ -360,6 +366,7 @@ export default {
               </v-col>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeToInputSec"
                   class="ma-0"
                   dense
@@ -374,6 +381,7 @@ export default {
               </v-col>
               <v-col cols="3">
                 <v-autocomplete
+                  data-public
                   v-model="timeToInputAmPm"
                   class="ma-0"
                   dense

--- a/src/components/ParametersForm.vue
+++ b/src/components/ParametersForm.vue
@@ -214,6 +214,7 @@ export default {
         <template #activator="{ on }">
           <div v-on="on">
             <v-select
+              data-public
               v-model="defaultType"
               class="select mx-4"
               :items="[

--- a/src/components/RunConfig/DateTimeSelector.vue
+++ b/src/components/RunConfig/DateTimeSelector.vue
@@ -356,6 +356,7 @@ export default {
               </v-fade-transition>
             </div>
             <v-autocomplete
+              data-public
               v-model="timezone_"
               :items="timezones"
               outlined

--- a/src/components/Schematics/Preview-Tile.vue
+++ b/src/components/Schematics/Preview-Tile.vue
@@ -108,6 +108,7 @@ export default {
 <template>
   <v-card class="preview-tile" tile>
     <v-autocomplete
+      data-public
       v-model="searchInput"
       autocomplete="new-password"
       class="mx-0 py-0"

--- a/src/components/SetStateDialog.vue
+++ b/src/components/SetStateDialog.vue
@@ -82,7 +82,7 @@ export default {
             >
           </v-card-title>
           <v-select
-            data-publicP
+            data-public
             v-model="selectedState"
             outlined
             :menu-props="{ offsetY: true }"

--- a/src/components/SetStateDialog.vue
+++ b/src/components/SetStateDialog.vue
@@ -82,6 +82,7 @@ export default {
             >
           </v-card-title>
           <v-select
+            data-publicP
             v-model="selectedState"
             outlined
             :menu-props="{ offsetY: true }"

--- a/src/pages/Admin/Teams/InviteUsers.vue
+++ b/src/pages/Admin/Teams/InviteUsers.vue
@@ -232,6 +232,7 @@ export default {
               />
 
               <v-autocomplete
+                data-public
                 v-model="invitation.role"
                 outlined
                 dense
@@ -335,6 +336,7 @@ export default {
 
                   <div class="actions d-flex align-center justify-end ml-auto">
                     <v-autocomplete
+                      data-public
                       v-model="u.role"
                       outlined
                       dense

--- a/src/pages/Agents/AgentFlowRunTable-Tile.vue
+++ b/src/pages/Agents/AgentFlowRunTable-Tile.vue
@@ -148,6 +148,7 @@ export default {
         :class="{ 'd-flex': $vuetify.breakpoint.mdAndUp }"
       >
         <v-select
+          data-public
           v-model="state"
           outlined
           class="state-filter"

--- a/src/pages/Agents/Agents.vue
+++ b/src/pages/Agents/Agents.vue
@@ -306,6 +306,7 @@ export default {
           <v-card width="320">
             <v-card-text class="pb-6">
               <v-autocomplete
+                data-public
                 ref="agents"
                 v-model="labelInput"
                 :items="allLabels"

--- a/src/pages/Dashboard/Automations/AddAction.vue
+++ b/src/pages/Dashboard/Automations/AddAction.vue
@@ -694,6 +694,7 @@ export default {
         <v-row class="mt-2">
           <v-col cols="12" md="4">
             <v-select
+              data-public
               v-model="apiToken"
               :items="secretNames"
               outlined
@@ -703,6 +704,7 @@ export default {
           </v-col>
           <v-col cols="12" md="4">
             <v-select
+              data-public
               v-model="severity"
               :items="severityLevels"
               outlined
@@ -802,6 +804,7 @@ export default {
       <v-row class="mt-4">
         <v-col cols="12" md="4">
           <v-select
+            data-public
             v-model="authToken"
             outlined
             :items="secretNames"

--- a/src/pages/Dashboard/FailedFlows-Tile.vue
+++ b/src/pages/Dashboard/FailedFlows-Tile.vue
@@ -113,6 +113,7 @@ export default {
         >
           <div slot="action" v-on="on">
             <v-select
+              data-public
               v-model="selectedDateFilter"
               class="time-interval-picker"
               :items="shortDateFilters"

--- a/src/pages/Dashboard/FailedTasks-Tile.vue
+++ b/src/pages/Dashboard/FailedTasks-Tile.vue
@@ -130,6 +130,7 @@ export default {
         >
           <div slot="action" v-on="on">
             <v-select
+              data-public
               v-model="selectedDateFilter"
               class="time-interval-picker"
               :items="shortDateFilters"

--- a/src/pages/Dashboard/FlowRunHeartbeat-Tile.vue
+++ b/src/pages/Dashboard/FlowRunHeartbeat-Tile.vue
@@ -66,6 +66,7 @@ export default {
   >
     <CardTitle title="Activity" icon="show_chart">
       <v-select
+        data-public
         slot="action"
         v-model="state"
         class="state-interval-picker font-weight-regular"

--- a/src/pages/Dashboard/Project-Selector.vue
+++ b/src/pages/Dashboard/Project-Selector.vue
@@ -99,6 +99,7 @@ export default {
 <template>
   <div>
     <v-autocomplete
+      data-public
       id="project-dropdown"
       v-model="projectSelect"
       class="project-selector"

--- a/src/pages/Dashboard/Summary-Tile.vue
+++ b/src/pages/Dashboard/Summary-Tile.vue
@@ -135,6 +135,7 @@ export default {
         <CardTitle title="Summary" icon="pi-flow-run">
           <div slot="action" v-on="on">
             <v-select
+              data-public
               v-model="selectedDateFilter"
               class="time-interval-picker"
               :items="dateFilters"

--- a/src/pages/Flow/Actions.vue
+++ b/src/pages/Flow/Actions.vue
@@ -259,6 +259,7 @@ export default {
   >
     <div class="version-selector">
       <v-select
+        data-public
         :value.sync="selectedVersion"
         :items="versions"
         dense

--- a/src/pages/Flow/Errors-Tile.vue
+++ b/src/pages/Flow/Errors-Tile.vue
@@ -162,6 +162,7 @@ export default {
         >
           <div slot="action" v-on="on">
             <v-select
+              data-public
               v-if="!flow.archived"
               v-model="selectedDateFilter"
               class="time-interval-picker"

--- a/src/pages/Flow/FlowRunHeartbeat-Tile.vue
+++ b/src/pages/Flow/FlowRunHeartbeat-Tile.vue
@@ -78,6 +78,7 @@ export default {
   <v-card v-intersect="{ handler: onIntersect }" class="pa-2" tile>
     <CardTitle title="Activity" icon="show_chart" :icon-color="state">
       <v-select
+        data-publicß
         slot="action"
         v-model="state"
         class="state-interval-picker font-weight-regular"

--- a/src/pages/Flow/FlowRunHeartbeat-Tile.vue
+++ b/src/pages/Flow/FlowRunHeartbeat-Tile.vue
@@ -78,7 +78,7 @@ export default {
   <v-card v-intersect="{ handler: onIntersect }" class="pa-2" tile>
     <CardTitle title="Activity" icon="show_chart" :icon-color="state">
       <v-select
-        data-publicß
+        data-public
         slot="action"
         v-model="state"
         class="state-interval-picker font-weight-regular"

--- a/src/pages/Flow/FlowRunTable-Tile.vue
+++ b/src/pages/Flow/FlowRunTable-Tile.vue
@@ -178,6 +178,7 @@ export default {
         :class="{ 'd-flex': $vuetify.breakpoint.mdAndUp }"
       >
         <v-select
+          data-public
           v-model="state"
           outlined
           class="state-filter"

--- a/src/pages/Flow/Run.vue
+++ b/src/pages/Flow/Run.vue
@@ -538,6 +538,7 @@ export default {
             <v-col cols="12" md="9" class="mt-n4 mt-md-0">
               <resettable-wrapper v-model="loggingLevel">
                 <v-select
+                  data-public
                   v-model="loggingLevel"
                   outlined
                   :items="loggingLevels"

--- a/src/pages/Flow/Settings/ClockForm.vue
+++ b/src/pages/Flow/Settings/ClockForm.vue
@@ -92,7 +92,7 @@ export default {
       checked: []
     }
   },
-  created(){
+  created() {
     const params = this.clock?.parameter_defaults ?? {}
 
     this.parameter = this.formatParams(this.allDefaultParameters, params)
@@ -133,14 +133,20 @@ export default {
     confirm() {
       const clockType =
         typeof this[this.clockToAdd] == 'string' ? 'CronClock' : 'IntervalClock'
-      const parameters = this.parameter != null && isValidJson(this.parameter) ? parseJson(this.parameter) : {}
-      const checked = Object.entries(parameters).reduce((result, [key, value]) => {
-        if(this.checked.includes(key)){
-          result[key] = value
-        }
+      const parameters =
+        this.parameter != null && isValidJson(this.parameter)
+          ? parseJson(this.parameter)
+          : {}
+      const checked = Object.entries(parameters).reduce(
+        (result, [key, value]) => {
+          if (this.checked.includes(key)) {
+            result[key] = value
+          }
 
-        return result
-      }, {})
+          return result
+        },
+        {}
+      )
       const clock = {
         type: clockType,
         [clockType == 'IntervalClock' ? 'interval' : 'cron']: this[
@@ -206,6 +212,7 @@ export default {
                   class="mt-2"
                 />
                 <v-autocomplete
+                  data-public
                   v-model="selectedTimezone"
                   :items="tzs"
                   outlined

--- a/src/pages/Flow/Settings/ClockForms/Simple.vue
+++ b/src/pages/Flow/Settings/ClockForms/Simple.vue
@@ -186,6 +186,7 @@ export default {
       />
 
       <v-select
+        data-public
         v-model="interval"
         :items="intervalOptions"
         class="text-h5 ml-2"
@@ -204,6 +205,7 @@ export default {
     >
       <div>...on the</div>
       <v-select
+        data-public
         v-model="minuteValue"
         :items="minutes"
         class="text-h5 ml-2 mr-1"
@@ -221,6 +223,7 @@ export default {
     >
       <div>...at the</div>
       <v-select
+        data-public
         v-model="hourValue"
         :items="hours"
         class="text-h5 ml-2 mr-1"

--- a/src/pages/Flow/Settings/General.vue
+++ b/src/pages/Flow/Settings/General.vue
@@ -306,6 +306,7 @@ export default {
                 <template #activator="{ on }">
                   <div v-on="on">
                     <v-select
+                      data-public
                       v-model="selected.projectId"
                       :items="sortedProjects"
                       item-value="id"

--- a/src/pages/Flow/Summary-Tile.vue
+++ b/src/pages/Flow/Summary-Tile.vue
@@ -156,6 +156,7 @@ export default {
         <CardTitle title="Flow Runs Summary" icon="pi-flow-run">
           <div slot="action" v-on="on">
             <v-select
+              data-public
               v-if="!flow.archived"
               v-model="selectedDateFilter"
               class="time-interval-picker"

--- a/src/pages/FlowRun/TaskRunHeartbeat-Tile.vue
+++ b/src/pages/FlowRun/TaskRunHeartbeat-Tile.vue
@@ -47,6 +47,7 @@ export default {
   <v-card v-intersect="{ handler: onIntersect }" class="pa-2" tile>
     <CardTitle title="Activity" icon="show_chart">
       <v-select
+        data-public
         slot="action"
         v-model="state"
         class="state-interval-picker font-weight-regular"

--- a/src/pages/FlowRun/TaskRunTable-Tile.vue
+++ b/src/pages/FlowRun/TaskRunTable-Tile.vue
@@ -162,6 +162,7 @@ export default {
       >
         <v-select
           v-model="state"
+          data-public
           outlined
           class="state-filter"
           :style="[

--- a/src/pages/Integrations/PagerDuty.vue
+++ b/src/pages/Integrations/PagerDuty.vue
@@ -292,6 +292,7 @@ export default {
         >
           <v-col cols="12" md="3">
             <v-select
+              data-public
               v-model="key.severity"
               :items="severityLevels"
               outlined

--- a/src/pages/Task/TaskRunHeartbeat-Tile.vue
+++ b/src/pages/Task/TaskRunHeartbeat-Tile.vue
@@ -53,6 +53,7 @@ export default {
   <v-card v-intersect="{ handler: onIntersect }" class="pa-2" tile>
     <CardTitle title="Activity in the last hour" icon="show_chart">
       <v-select
+        data-public
         slot="action"
         v-model="state"
         class="state-interval-picker font-weight-regular"

--- a/src/pages/Task/TaskRunTable-Tile.vue
+++ b/src/pages/Task/TaskRunTable-Tile.vue
@@ -124,6 +124,7 @@ export default {
         <CardTitle :title="tableTitle" icon="pi-task-run">
           <div slot="action" v-on="on">
             <v-select
+              data-public
               v-model="selectedDateFilter"
               class="time-interval-picker"
               :items="dateFilters"

--- a/src/pages/TaskRun/TaskRunHeartbeat-Tile.vue
+++ b/src/pages/TaskRun/TaskRunHeartbeat-Tile.vue
@@ -69,6 +69,7 @@ export default {
   <v-card v-intersect="{ handler: onIntersect }" class="pa-2" tile>
     <CardTitle title="Activity" icon="show_chart">
       <v-select
+        data-public
         slot="action"
         v-model="state"
         class="state-interval-picker font-weight-regular"

--- a/src/pages/TeamSettings/Members.vue
+++ b/src/pages/TeamSettings/Members.vue
@@ -460,6 +460,7 @@ export default {
           validate-on-blur
         />
         <v-select
+          data-public
           v-model="roleInput"
           outlined
           :menu-props="{ offsetY: true }"

--- a/src/pages/TeamSettings/Members/Members-Table.vue
+++ b/src/pages/TeamSettings/Members/Members-Table.vue
@@ -339,6 +339,7 @@ export default {
       @confirm="updateRole(selectedUser.membershipId, roleInput)"
     >
       <v-select
+        data-public
         v-model="roleInput"
         class="mt-6"
         outlined

--- a/src/pages/TeamSettings/Projects.vue
+++ b/src/pages/TeamSettings/Projects.vue
@@ -815,6 +815,7 @@ export default {
         </p>
 
         <v-autocomplete
+          data-public
           v-model="moveToProjectInput"
           :items="moveToProjectDropdownItems"
           :menu-props="{

--- a/src/pages/TeamSettings/Service-Accounts.vue
+++ b/src/pages/TeamSettings/Service-Accounts.vue
@@ -295,6 +295,7 @@ export default {
           @keydown.enter="addServiceAccount"
         />
         <v-select
+          data-public
           v-model="roleInput"
           outlined
           :menu-props="{ offsetY: true }"

--- a/src/pages/Tutorials/FlowRun/CreateProjectStep.vue
+++ b/src/pages/Tutorials/FlowRun/CreateProjectStep.vue
@@ -135,6 +135,7 @@ export default {
       </v-col>
       <v-col cols="12" md="6" xl="4" class="auto pa-0">
         <v-select
+          data-public
           v-model="selectedProjectId"
           :items="projects"
           class="mb-5"

--- a/src/pages/UserSettings/Profile.vue
+++ b/src/pages/UserSettings/Profile.vue
@@ -151,6 +151,7 @@ export default {
         ></v-text-field>
 
         <v-autocomplete
+          data-public
           v-model="selectedTimezone"
           :items="tzs"
           label="Time Zone"

--- a/src/plugins/logrocket.js
+++ b/src/plugins/logrocket.js
@@ -15,6 +15,10 @@ const initializeLogrocket = () => {
   ) {
     LogRocket.init(process.env.VUE_APP_LOG_ROCKET_PUBLIC_ID, {
       release: process.env.VUE_APP_RELEASE_TIMESTAMP,
+      dom: {
+        textSanitizer: true,
+        inputSanitizer: true,
+      },
       network: {
         // Requests in the blockedRequests list
         // will be sanitized from analytics

--- a/src/plugins/logrocket.js
+++ b/src/plugins/logrocket.js
@@ -16,8 +16,7 @@ const initializeLogrocket = () => {
     LogRocket.init(process.env.VUE_APP_LOG_ROCKET_PUBLIC_ID, {
       release: process.env.VUE_APP_RELEASE_TIMESTAMP,
       dom: {
-        textSanitizer: true,
-        inputSanitizer: true,
+        inputSanitizer: true
       },
       network: {
         // Requests in the blockedRequests list


### PR DESCRIPTION
## Describe this PR
Adds input sanitizer so that new inputs are hidden in log rocket as default.  Also adds data-public to selects and auto-complete which do not contain sensitive data. 