### PR TITLE
BugFix: Add once to intersect on lastTenRuns

### DIFF
--- a/src/components/LastTenRuns.vue
+++ b/src/components/LastTenRuns.vue
@@ -177,7 +177,7 @@ export default {
 <template>
   <div>
     <BarChart
-      v-intersect="{ handler: onIntersect }"
+      v-intersect.once="onIntersect"
       :items="preppedFlowRuns"
       :loading="loadingKey > 0"
       :height="50"


### PR DESCRIPTION
Only call onIntersect on mount and once intersected to enable easier scrolling through the flow table.  This potentially adds more data and polling but should still remove the big initial poll of pulling everything on the page even when not visible.  Based on vuetify docs here: https://vuetifyjs.com/en/api/v-intersect/#argument

Closes #1179 
