### PR TITLE
BugFix: Remove confusing reference to RBAC on plans page

### DIFF
--- a/src/components/Plans/Standard.vue
+++ b/src/components/Plans/Standard.vue
@@ -177,15 +177,6 @@ export default {
           <div class="mt-3 d-flex align-center justify-center">
             <span class="rounded-circle plans-feature-icon">
               <v-icon small>
-                fad fa-user-shield
-              </v-icon>
-            </span>
-            <span class="ml-2">Role-based permissioning</span>
-          </div>
-
-          <div class="mt-3 d-flex align-center justify-center">
-            <span class="rounded-circle plans-feature-icon">
-              <v-icon small>
                 fad fa-siren-on
               </v-icon>
             </span>

--- a/src/utils/plans.js
+++ b/src/utils/plans.js
@@ -209,12 +209,6 @@ export const authorizationFeatures = [
     value: 2
   },
   {
-    name: 'RBAC',
-    description: 'Assign roles to users to control access',
-    plan: 'enterprise',
-    value: 3
-  },
-  {
     name: 'Custom Permissions',
     description: 'Assign granular permissions, including per-project limits',
     plan: 'enterprise',


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->

Resolve confusion about whether RBAC is included in Standard or Enterprise Tier plans and align the plans page more closely with the [website pricing page](https://www.prefect.io/pricing). 
## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
No connected issue but raised by sales team in the website monday board: https://prefect-squad.monday.com/boards/1988645165/pulses/2065256173

## Tests and performance

 - [x] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [x] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
