### PR TITLE
BugFix: Remove automations tab from flow page on Server

### DIFF
--- a/src/components/Nav/TeamMenu.vue
+++ b/src/components/Nav/TeamMenu.vue
@@ -102,7 +102,7 @@ export default {
           </v-list-item-content>
         </v-list-item>
 
-        <v-list-item :to="'/team/actions'">
+        <v-list-item :disabled="!isCloud" :to="'/team/actions'">
           <v-list-item-avatar>
             <span class="auto-icon">
               <i class="fad fa-random" style="width: 24px; height: 24px;"></i>

--- a/src/pages/Flow/Flow.vue
+++ b/src/pages/Flow/Flow.vue
@@ -172,6 +172,11 @@ export default {
       set(value){
         this.$router.replace({query: { [value]: null }})
       }
+    },
+    flowTabs() {
+      return this.isCloud
+        ? this.tabs
+        : this.tabs.filter(tab => tab.name !== 'Automations')
     }
   },
   watch: {
@@ -299,7 +304,7 @@ export default {
         :versions="versions"
       />
       <span slot="tabs" style="width: 100%;"
-        ><NavTabBar :tabs="tabs" v-if="flowGroup" page="flow"
+        ><NavTabBar :tabs="flowTabs" v-if="flowGroup" page="flow"
       /></span>
     </SubPageNav>
 


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->
- Removes the automations tab on the flow page
- Disables the Automation Actions link in the team menu 
## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
Resolves #1168 

## Tests and performance

 - [x] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [x] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
