### PR TITLE
BugFix: Hide calendar schedule banner on Server

### DIFF
--- a/src/pages/Calendar/Calendar-Day.vue
+++ b/src/pages/Calendar/Calendar-Day.vue
@@ -44,7 +44,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('api', ['connected']),
+    ...mapGetters('api', ['connected', 'isCloud']),
     ...mapGetters('tenant', ['tenant']),
     ...mapGetters('user', ['timezone']),
     intervalCount() {
@@ -184,12 +184,13 @@ export default {
       })
     },
     showScheduleBanner() {
-      this.scheduleBanner =
-        this.flow?.is_schedule_active && this.upcoming > 8 && !this.closeBanner
-          ? true
-          : !this.closeBanner
-          ? new Date(this.date) > new Date()
-          : false
+      if (this.closeBanner || !this.isCloud) {
+        this.scheduleBanner = false
+      } else if (this.flow?.is_schedule_active && this.upcoming > 8) {
+        this.scheduleBanner = true
+      } else {
+        this.scheduleBanner = new Date(this.date) > new Date()
+      }
     },
     eventColor(event) {
       return event.state ? event.state : 'primary'

--- a/src/pages/Calendar/RunMenu.vue
+++ b/src/pages/Calendar/RunMenu.vue
@@ -3,6 +3,7 @@ import DurationSpan from '@/components/DurationSpan'
 import { formatTime } from '@/mixins/formatTimeMixin'
 import FlowName from '@/pages/Calendar/FlowName'
 import ExternalLink from '@/components/ExternalLink'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -16,7 +17,15 @@ export default {
     type: { type: String, required: false, default: 'task-run' },
     active: { type: Boolean, required: true }
   },
-  computed: {},
+  computed: {
+    ...mapGetters('api', ['isCloud']),
+    showScheduleBanner() {
+      if (this.run.state === 'Scheduled' && this.active && this.isCloud) {
+        return true
+      }
+      return false
+    }
+  },
   methods: {
     statusStyle(state) {
       return {
@@ -35,7 +44,7 @@ export default {
 <template>
   <v-card tile class="pointer">
     <v-alert
-      v-if="run.state === 'Scheduled' && active"
+      v-if="showScheduleBanner"
       class="mx-2 mt-2 mb-0 text-caption radius"
       type="warning"
       icon="announcement"

--- a/src/pages/Calendar/RunMenu.vue
+++ b/src/pages/Calendar/RunMenu.vue
@@ -20,10 +20,7 @@ export default {
   computed: {
     ...mapGetters('api', ['isCloud']),
     showScheduleBanner() {
-      if (this.run.state === 'Scheduled' && this.active && this.isCloud) {
-        return true
-      }
-      return false
+      return this.run.state === 'Scheduled' && this.active && this.isCloud
     }
   },
   methods: {


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->
Hides the "Reminder! The Prefect Scheduler will only schedule 10 runs in advance" banner for users on Server

## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
Resolves #1178 

## Tests and performance

 - [x] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [x] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
