### PR TITLE
BugFix: Remove "user content" from each heading in the tutorial menu

### DIFF
--- a/src/utils/markdownParser.js
+++ b/src/utils/markdownParser.js
@@ -21,7 +21,11 @@ export function parser(md) {
           value: '# '
         }
       })
-      .use(html)
+      .use(html, {
+        sanitize: {
+          clobberPrefix: ''
+        }
+      })
       .process(md, (err, file) => {
         result = String(file)
       })


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->
- Adds [clobberPrefix](https://github.com/syntax-tree/mdast-util-to-hast#:~:text=Prefix%20to%20use%20before%20the%20id%20attribute%20on%20footnotes%20to%20prevent%20it%20from%20clobbering%20(string%2C%20default%3A%20%27user%2Dcontent%2D%27).%20DOM%20clobbering%20is%20this%3A) to remove the `user-content` prefix

## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
Resolves #1193 

## Tests and performance

 - [x] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [x] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
