### PR TITLE
BugFix: Web hook URL validation

### DIFF
--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -107,7 +107,7 @@ export default {
         requiredCombo: val =>
           (!!val && val.length > 0) || 'At least one number is required',
         url: val => {
-          const pattern = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,256}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/
+          const pattern = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/
           return pattern.test(val) || 'Invalid URL.'
         }
       },

--- a/src/components/CloudHookForm.vue
+++ b/src/components/CloudHookForm.vue
@@ -107,7 +107,7 @@ export default {
         requiredCombo: val =>
           (!!val && val.length > 0) || 'At least one number is required',
         url: val => {
-          const pattern = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/
+          const pattern = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,256}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/
           return pattern.test(val) || 'Invalid URL.'
         }
       },


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->
Enables users to be able to enter a long url when trying to add a web hook

## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
Resolves #1205 

## Tests and performance

 - [x] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [x] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
