### PR TITLE
Feature: Allow dates in the past to be used as parameter values when using date picker

### DIFF
--- a/src/components/CustomInputs/KeyValueTypeInputs/DateInput.vue
+++ b/src/components/CustomInputs/KeyValueTypeInputs/DateInput.vue
@@ -1,6 +1,7 @@
 <template>
   <date-time
     v-model="internalValue"
+    allow-past-date
     :disabled="disabled"
     :text-field-props="{
       label: 'Value',

--- a/src/components/DateTime.vue
+++ b/src/components/DateTime.vue
@@ -24,6 +24,11 @@ export default {
       type: String,
       required: false,
       default: () => ''
+    },
+    allowPastDate: {
+      type: Boolean,
+      required: false,
+      default: () => false
     }
   },
   data() {
@@ -48,7 +53,7 @@ export default {
     ...mapGetters('user', ['timezone']),
     // The current date in YYYY-MM-DD format
     currentDate() {
-      if (!this.currentDateTimeMoment) return null
+      if (!this.currentDateTimeMoment || this.allowPastDate) return null
       return this.currentDateTimeMoment.format('YYYY-MM-DD')
     },
     // Selected date and time value, as derived from date & time inputs.
@@ -273,7 +278,7 @@ export default {
                 <v-col cols="12" class="py-0">
                   <v-scroll-x-transition>
                     <v-alert
-                      v-if="timeInPast"
+                      v-if="!allowPastDate && timeInPast"
                       border="left"
                       colored-border
                       elevation="2"


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->
Allows dates in the past to be used as parameter values when using date picker

## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
Resolves #1180 

## Tests and performance

 - [x] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [x] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
