### PR TITLE
BugFix: Improve loading logic for automation tab on Flow Page

### DIFF
--- a/src/pages/Flow/Automations-Tile.vue
+++ b/src/pages/Flow/Automations-Tile.vue
@@ -51,7 +51,6 @@ export default {
         (a, b) => new Date(b.created) - new Date(a.created)
       )
       this.sortedHooks = sorted
-      console.log('end of load', sorted)
       this.loadCards = false
     }
   },

--- a/src/pages/Flow/Automations-Tile.vue
+++ b/src/pages/Flow/Automations-Tile.vue
@@ -51,6 +51,7 @@ export default {
         (a, b) => new Date(b.created) - new Date(a.created)
       )
       this.sortedHooks = sorted
+      console.log('end of load', sorted)
       this.loadCards = false
     }
   },
@@ -99,7 +100,7 @@ export default {
           >
         </v-col>
         <v-progress-circular
-          v-if="!sortedHooks.length && loadingHook > 0"
+          v-if="loadCards || (!sortedHooks.length && loadingHook > 0)"
           class="mx-auto my-4"
           indeterminate
           color="primary"
@@ -111,7 +112,7 @@ export default {
         >
         <v-col v-for="(hook, i) in sortedHooks" :key="i" cols="12">
           <v-skeleton-loader
-            v-if="loadingHook > 0 || loadCards"
+            v-if="loadingHook > 0"
             type="list-item-avatar-three-line"
             height="72"
           ></v-skeleton-loader


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->


## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
Improve the loading logic for the automations tab on the flow page.  This tab takes a while to load and needs two queries. 
 The old logic left a gap between the loading indicator connected to each query.  This PR attaches the loading state connected to the filter logic to the first loading indicator instead of the second, 

## Tests and performance

 - [ ] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [ ] No new packages are added or package size and performance considerations are discussed below
 - [ ] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
