### PR TITLE
BugFix: Do not call unsubscribe agents if it is not a function

### DIFF
--- a/src/components/LabelWarning.vue
+++ b/src/components/LabelWarning.vue
@@ -107,12 +107,13 @@ export default {
     },
     async onIntersect([entry]) {
       if (entry.isIntersecting) {
+        console.log('setting')
         this.unsubscribeAgents = await this.$store.dispatch(
           'polling/subscribe',
           'agents'
         )
       } else {
-        this.unsubscribeAgents()
+        if (this.unsubscribeAgents) this.unsubscribeAgents()
       }
     }
   }

--- a/src/components/LabelWarning.vue
+++ b/src/components/LabelWarning.vue
@@ -107,7 +107,6 @@ export default {
     },
     async onIntersect([entry]) {
       if (entry.isIntersecting) {
-        console.log('setting')
         this.unsubscribeAgents = await this.$store.dispatch(
           'polling/subscribe',
           'agents'


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->

Prevents an error in the terminal that arises from calling unsubscribeAgents when it hasn't been set as a function. This may be a superficial fix that means we are subscribed to agent polling for longer than we need to be.  I do not think the overall impact is large but would appreciate @stackoverfloweth's eyes on this to check there is nothing more nefarious. 


## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
Closes #1216 

## Tests and performance

 - [ ] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [ ] No new packages are added or package size and performance considerations are discussed below
 - [ ] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
