### PR TITLE
BugFix: Fix Skip on SetStateDialog

### DIFF
--- a/src/components/SetStateDialog.vue
+++ b/src/components/SetStateDialog.vue
@@ -17,7 +17,8 @@ export default {
   },
   methods: {
     onIntersect([entry]) {
-      this.$apollo.queries.taskRunIds.skip = !entry.isIntersecting
+      this.$apollo.queries.taskRunIds.skip =
+        !this.flowRun || !entry.isIntersecting
     }
   },
   apollo: {
@@ -29,9 +30,6 @@ export default {
           parentMapIndex: -1,
           childMapIndex: null
         }
-      },
-      skip() {
-        return !this.flowRun
       },
       pollInterval: 10000,
       update: data => data.task_run

--- a/src/pages/TaskRun/Restart-Dialog.vue
+++ b/src/pages/TaskRun/Restart-Dialog.vue
@@ -58,7 +58,7 @@ export default {
         this.dialog = false
         await this.writeLogs()
         let taskStates = []
-        if (this.utilityDownstreamTasks.length) {
+        if (this.utilityDownstreamTasks?.length) {
           taskStates = this.utilityDownstreamTasks.map(task => {
             return {
               version: task.task.task_runs[0].version,


### PR DESCRIPTION
## Description
<! -- What is it meant to do? -->
Makes sure we skip the task run ids query when no flow run id is available. 

## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->


## Tests and performance

 - [ ] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [ ] No new packages are added or package size and performance considerations are discussed below
 - [ ] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
