### PR TITLE
BugFix: Add error handling to the delete-service-account mutation

### DIFF
--- a/src/pages/TeamSettings/Service-Accounts-Table.vue
+++ b/src/pages/TeamSettings/Service-Accounts-Table.vue
@@ -191,24 +191,30 @@ export default {
     async removeAccount(id) {
       this.isRemovingUser = true
 
-      const res = await this.$apollo.mutate({
-        mutation: require('@/graphql/User/delete-service-account.gql'),
-        variables: { id }
-      })
+      try {
+        const res = await this.$apollo.mutate({
+          mutation: require('@/graphql/User/delete-service-account.gql'),
+          variables: { id }
+        })
 
-      if (res?.data?.delete_service_account?.success) {
-        this.$emit('successful-action', 'The service account has been removed.')
-        this.$apollo.queries.tenantUsers.refetch()
-      } else {
+        if (res?.data?.delete_service_account?.success) {
+          this.$emit(
+            'successful-action',
+            'The service account has been removed.'
+          )
+          this.$apollo.queries.tenantUsers.refetch()
+        }
+      } catch (error) {
         this.$emit(
           'failed-action',
           'Something went wrong while trying to remove this service account. Please try again.'
         )
+        throw error
+      } finally {
+        this.isRemovingUser = false
+        this.dialogRemoveUser = false
+        this.selectedUser = null
       }
-
-      this.isRemovingUser = false
-      this.dialogRemoveUser = false
-      this.selectedUser = null
     },
     updateRole(account) {
       this.$emit('update', account)


### PR DESCRIPTION
## Description
Adds a try/catch block to the delete-service-account mutation so when an error appears, it closes the modal and emits an error alert. 

## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->
https://github.com/PrefectHQ/cloud/issues/3905


## Tests and performance

 - [ ] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [ ] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
