### PR TITLE
Bugfix: Service account roles

### DIFF
--- a/src/pages/TeamSettings/Service-Accounts.vue
+++ b/src/pages/TeamSettings/Service-Accounts.vue
@@ -197,7 +197,10 @@ export default {
         return {}
       },
       pollInterval: 10000,
-      update: data => data.auth_role
+      update(data) {
+        if (!data) return
+        return data.auth_role
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This PR should fix an issue where the service accounts button was always disabled due to a swallowed error in the `roles` query