### PR TITLE
Chore: Update Build image to use Circle2.0 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
 
   build-docker:
     docker:
-      - image: circleci/python
+      - image: cimg/python:3.9.7-node
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PW


### PR DESCRIPTION
## Description
The current image `circleci/python` is [deprecated](https://circleci.com/docs/next-gen-migration-guide), this PR bumps us to a supported image. 
