### PR TITLE
Chore: Add check on `hide_freeze_banner`; add standard license checks again

### DIFF
--- a/src/layouts/SubPageNav.vue
+++ b/src/layouts/SubPageNav.vue
@@ -49,7 +49,10 @@ export default {
       return (
         this.canShowBanners &&
         this.isCloud &&
-        (this.planType('FREE') || this.planType('STARTER'))
+        !this.license.terms?.hide_freeze_banner &&
+        (this.planType('FREE') ||
+          this.planType('STARTER') ||
+          this.planType('STANDARD'))
       )
     }
   },


### PR DESCRIPTION
## Description
Adds again the checks on `STANDARD` licenses that were removed with #1366 with an additional check on `hide_freeze_banner` in the license terms.