### PR TITLE
Bugfix: Subpage nav should account for null licenses

### DIFF
--- a/src/components/EndOfLifeBanner.vue
+++ b/src/components/EndOfLifeBanner.vue
@@ -11,7 +11,7 @@ export default {
       return this.planType('FREE')
     },
     frozen() {
-      return this.license.terms?.frozen
+      return this.license?.terms?.frozen
     }
   }
 }

--- a/src/layouts/SubPageNav.vue
+++ b/src/layouts/SubPageNav.vue
@@ -50,6 +50,7 @@ export default {
       return (
         this.canShowBanners &&
         this.isCloud &&
+        this.license &&
         !this.license.terms?.hide_freeze_banner &&
         (this.planType('FREE') ||
           this.planType('STARTER') ||

--- a/src/layouts/SubPageNav.vue
+++ b/src/layouts/SubPageNav.vue
@@ -50,8 +50,7 @@ export default {
       return (
         this.canShowBanners &&
         this.isCloud &&
-        this.license &&
-        !this.license.terms?.hide_freeze_banner &&
+        !this.license?.terms?.hide_freeze_banner &&
         (this.planType('FREE') ||
           this.planType('STARTER') ||
           this.planType('STANDARD'))


### PR DESCRIPTION
Fixes an issue where the subpage nav component was throwing an error when the license object was null or undefined. 
