### PR TITLE
Bugfix: allow embedding only from current origin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -150,6 +150,9 @@ Content-Security-Policy = """ \
             'self' \
             ; \
 
+      frame-ancestors \
+            'self' \
+            ; \
       
       frame-src \
             'self' \


### PR DESCRIPTION
Add frame-ancestors 'self' to Content-Security-Policy (equivalent to X-Frame-Options SAMEORIGIN) to prevent clickjacking attacks.

Closes: https://github.com/PrefectHQ/devsecops/issues/833

## Description
<! -- What is it meant to do? -->


## Linked Issues
<! -- Use a key word (e.g. closes or resolves) to close related issues  -->


## Tests and performance

 - [x] Changes to any .js files are covered by existing tests or this PR adds new tests (if not please explain why below)
 - [x] No new packages are added or package size and performance considerations are discussed below
 - [x] PR Title fits our [changelog format](https://github.com/PrefectHQ/ui#readme)

 ## Releases/Changelog cuts only
 - [ ] Completed the [QA Checklist](https://www.notion.so/prefect/Cloud-UI-QA-Checklist-038a5a5d40a249d78232917ad1b923b9) in staging
