### PR TITLE
Chore: Remove source maps from webpack prod output

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -60,7 +60,6 @@ module.exports = {
   },
 
   configureWebpack: {
-    devtool: 'source-map',
     optimization: {
       splitChunks: {
         chunks: 'all',


### PR DESCRIPTION
## Description
These should only be accessible in development builds and not production.