### PR TITLE
Chore: Add productionSourceMap setting

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,7 @@ const WorkerPlugin = require('worker-plugin')
 const webpack = require('webpack')
 
 module.exports = {
+  productionSourceMap: false,
   chainWebpack: config => {
     config.module
       .rule('md')


### PR DESCRIPTION
## Description
#1391 removed the webpack-level source map setting but I didn't realize there's a vue-cli-service level setting for this as well. Hopefully this'll address that.